### PR TITLE
Release v0.1.1

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.1rc3"
+current_version = "0.1.1"
 parse = """(?x)
     ^
     (?P<major>0|[1-9]\\d*)\\.

--- a/office4ai/__init__.py
+++ b/office4ai/__init__.py
@@ -16,7 +16,7 @@ Main Components:
 - PresentationHandler: PowerPoint presentation operations
 """
 
-__version__: str = "0.1.1rc3"
+__version__: str = "0.1.1"
 __all__ = [
     "__version__",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office4ai"
-version = "0.1.1rc3"
+version = "0.1.1"
 description = "A powerful Office document management environment designed for AI agents to interact with Office documents"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "office4ai"
-version = "0.1.1rc2"
+version = "0.1.1rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- 发布 v0.1.1 正式版
- 实现 PPT 全部 21 个 MCP 工具、DTO、Namespace 及完整测试覆盖
- 完成 Word 剩余 12 个 MCP 工具（9→21），包括 export_content 和 comment 系列
- 实现 Desktop Window Resources Phase 1（Word/PPT 独立窗口资源）
- 添加集中式日志配置（loguru + stdlib logging 统一）
- 统一 PPT DTO 命名规范为 snake_case + camelCase alias
- 添加自动证书管理模块并重构 CLI 为子命令模式
- 实现 MCP Server 封装升级：声明式 BaseTool + async 生命周期
- 添加 Claude Code 自定义 Skills（code-review, fix-review, UAT）
- 大量 E2E 测试和契约测试覆盖

## Stats
- 333 files changed, ~56,900 insertions
- 85 commits since last release

## Test plan
- [x] Unit tests pass (`poe test-unit`)
- [x] Contract tests for all 21 Word tools and 21 PPT tools
- [ ] E2E manual tests validated
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)