### PR TITLE
feat(word): expose 4 OASP /word Draft table MCP tools (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ __marimo__/
 manual_tests/.test_working/
 
 # Auto-generated fixture files (recreated by ensure_fixtures / create_*_fixtures.py)
+manual_tests/fixtures/
 manual_tests/word/fixtures/*/
 manual_tests/ppt/fixtures/*/
 

--- a/docs/manual_tests/word_table_v0.2.0.md
+++ b/docs/manual_tests/word_table_v0.2.0.md
@@ -1,0 +1,191 @@
+# Word 表格 4 个 MCP Tools 手工验收清单 (Issue #8 / OASP v0.2.0)
+
+> **范围**：`word_merge_cells` / `word_update_table_cell` / `word_update_table_row_column` / `word_update_table_format`
+> **协议引用**：https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+> **关联**：JIAQIA/office4ai#8 · JIAQIA/office-editor4ai#23 (PR #27) · JIRA OF4AI-10 / OF4AI-11
+
+本清单镜像 Issue #8 「手工测试清单（端到端视觉验证）」11 项，划分为：
+
+- **A. 自动化部分**：跑 `test_word_table_e2e.py --mode tables`，脚本完成 OOXML 结构验证；你目测视觉
+- **B. 手工部分**：3 个错误码场景 + AI 业务闭环，必须手工触发
+- **C. 跨仓注意**：Server 侧未做的事
+
+---
+
+## 前置准备
+
+```bash
+# 1. 确保 office4ai 测试套件已通过
+uv run poe pre-commit            # 应该 ✅ 887 passed
+
+# 2. 确保已生成证书并安装到系统信任库
+uv run office4ai-mcp setup       # 仅首次
+
+# 3. 启动 office-editor4ai Add-In（另一个终端）
+cd /Users/jqq/WebstormProjects/office-editor4ai/word-editor4ai
+pnpm start                       # 或 npm start
+```
+
+确认：
+- [ ] office4ai 单元 + 契约测试全部通过（`poe pre-commit`）
+- [ ] office-editor4ai 已合入 PR #27（含 4 个新事件 Handler + `documentStructure.tables[]` 字段）
+- [ ] Add-In dev server 在跑
+
+---
+
+## A. 自动化场景（跑脚本 + 你目测）
+
+### A.0 端到端连通性 (Issue #8 项 1)
+
+```bash
+uv run python manual_tests/word/test_word_table_e2e.py --mode health
+```
+
+**预期**：
+```
+✅ Workspace 运行正常
+✅ 4 个新表格事件均已注册到 request_registry: [
+  'word:merge:cells', 'word:update:tableCell',
+  'word:update:tableRowColumn', 'word:update:tableFormat'
+]
+```
+
+- [ ] **A.0** Workspace 启动成功，4 个事件注册到 `request_registry`
+
+---
+
+### A.1～A.5 表格流水线（Issue #8 项 2/3/4/5/6 合并）
+
+```bash
+uv run python manual_tests/word/test_word_table_e2e.py --mode tables
+```
+
+脚本将：
+
+1. 启动 Workspace + 自动激活 Word Add-In
+2. 复制 `manual_tests/fixtures/empty.docx` 为工作副本并打开
+3. 依次调用（顺序经过 Word.js API 限制重排）：
+   1. `insert_table 5×4`
+   2. **`update_table_format(columnWidths=[120,80,80,80])` — 必须在 merge 之前**
+      （Word.js `TableColumnCollection` 在合并表上不可访问，详见
+      [office-editor4ai#29](https://github.com/JIAQIA/office-editor4ai/issues/29) /
+      [PR #31](https://github.com/JIAQIA/office-editor4ai/pull/31)）
+   3. `merge_cells`（首行 4 列合并）
+   4. `update_table_cell`（蓝底白字加粗设置首行表头）
+   5. `update_table_row_column`（4 行数据）
+   6. `update_table_cell`（标签列灰底加粗）
+   7. `update_table_format(borders + cellPadding + alignment="Centered")` — 这些在合并表上仍可用
+4. 调用一次缺省 `tableId` 的 `update_table_cell` 验证「光标解析」路径
+5. 触发 Word 保存，用 python-docx 读取 OOXML 结构验证：
+   - 表格存在
+   - 首行被合并（所有底层 `_tc` 指向同一节点）
+   - 首行单元格背景色 = `#1F4E79`
+   - 第 2 行第 0/1 列 = "甲方" / "ACME Corp"
+   - `tblGrid` 列数 = 4
+
+> ⚠️ **Word.js API 限制（Microsoft 平台级硬限制）**：含合并单元格的表上**无法**通过
+> `TableColumnCollection` 设置列宽——这是 Microsoft Word.js API 的限制，与协议或
+> Add-In 实现无关。AI 在使用这套工具时，应先用 `update_table_format(columnWidths=...)`
+> 设好列宽，再做合并。`update_table_format` 调用上**避开** `columnWidths` 仍可在合并
+> 表上工作（用于 borders / alignment / cellPadding 等其它字段）。
+
+**预期脚本输出尾部**：
+```
+  ✅ 表格数 = 1
+  ✅ 首行已合并 (merge_cells)
+  ✅ 首行单元格背景色 = #1F4E79 (update_table_cell)
+  ✅ 第 2 行文本 = ['甲方', 'ACME Corp'] (update_table_row_column)
+  ✅ tblGrid 列数 = 4，宽度 (dxa) = [...] (update_table_format)
+==========================================================
+✅ E2E 表格流水线通过；请打开下面文件目测视觉效果：
+   manual_tests/.test_working/empty_<timestamp>.docx
+```
+
+**目测验收项**（打开脚本输出的 `.docx`）：
+
+- [ ] **A.1** `word_merge_cells` 视觉：首行合并为单个跨整行单元格（Issue #8 项 2）
+- [ ] **A.2** `word_update_table_cell` 视觉：首行 = 蓝底 (`#1F4E79`) + 居中 + 加粗 + 白字「甲方信息」（Issue #8 项 3）
+- [ ] **A.3** `word_update_table_row_column` 视觉：第 2~5 行有「甲方/地址/联系人/日期」 + 对应值（Issue #8 项 4）
+- [ ] **A.4** `word_update_table_format` 视觉：所有单元格有边框、列宽明显是 [120, 80, 80, 80] pt（首列宽于其他三列）、整表居中、单元格四周内边距均匀（Issue #8 项 5）
+- [ ] **A.5** 标签列（甲方/地址/...）显示为灰底加粗
+- [ ] **A.6** 缺省 `tableId` 命中：脚本第二阶段日志含 `omitted-tableId update_table_cell OK`（Issue #8 项 6）
+
+---
+
+## B. 错误码场景
+
+### B.2 + B.3：已自动化 (随 `--mode tables` 一起跑)
+
+`--mode tables` 在 OOXML 验证之后会自动跑 B.2 + B.3，输出形如：
+
+```
+🚨 错误码场景（B.2 + B.3 自动触发）...
+  --- B.2 不存在的 tableId → 3010 ELEMENT_NOT_FOUND ---
+    ✅ B.2 错误码包含 3010: ...
+  --- B.3 合并冲突 → 3014 ALREADY_MERGED ---
+    ✅ B.3 错误码包含 3014: ...
+```
+
+- [ ] **B.2** 不存在的 `tableId` → 3010 ELEMENT_NOT_FOUND（Issue #8 项 8）
+- [ ] **B.3** 已合并区域上再次合并 → 3014 ALREADY_MERGED（Issue #8 项 9）
+
+### B.1 缺省 tableId + 光标不在表格内 → 3013 (Issue #8 项 7)
+
+需要单独跑——脚本不能操控 Word 光标，必须人手把光标移出表格。
+
+1. **不要关闭** `--mode tables` 留下来的 `.docx` 文件（仍开在 Word 里）
+2. 在 Word 中**点击表格之外的某个普通段落**（让光标离开表格）
+3. 重新启动 Add-In dev server（如果停了）
+4. 跑：
+
+```bash
+uv run python manual_tests/word/test_word_table_e2e.py --mode b1
+```
+
+预期输出：
+```
+✅ B.1 错误码包含 3013: ...Cursor is not inside a table...
+```
+
+- [ ] **B.1** 错误码包含 `3013`
+
+---
+
+## C. 跨仓 / 业务闭环
+
+### C.1 `word:get:documentStructure` 升级 (Issue #8 项 10)
+
+> ⚠️ **本仓库 Server 侧未做该升级**。`docs/word.py::DocumentStructure` 仍只暴露
+> `paragraphCount` / `tableCount` / `imageCount` / `sectionCount`。
+> Add-In #23 (PR #27) 已经在响应里返回 `tables: [...]`，但 Server DTO 暂未声明，
+> 字段会被 Pydantic 静默忽略。
+>
+> **可选跟进 Issue**（不阻塞本批 4 个 Tool 转 Stable）：
+> 在 `WordGetDocumentStructureResponse.data` 上扩展 `tables: list[TableSummary] | None`。
+> `TableSummary` DTO 已经在 `dtos/word.py` 中定义，仅缺一处装配。
+
+- [ ] **C.1** （可选）记录新 Issue 跟踪 Server 侧 `documentStructure.tables[]` 装配
+
+### C.2 AI 业务闭环（合同表头场景）(Issue #8 项 11)
+
+让一个真实接入了 4 个 MCP Tool 的 LLM Agent 在空白文档执行：
+
+> 「创建一份甲方信息表，首行作为横跨整行的'甲方信息'蓝底白字居中表头，下方为
+> 标签-填写区两列结构（标签列灰底加粗、填写区白底），整表居中、列宽 [80, 200]、
+> 内细外粗边框」
+
+- [ ] **C.2** AI 单次会话内通过组合调用 4 个 Tool 完成；用户**无需右键合并 / 无需手工调样式**
+
+---
+
+## 验收完成后
+
+1. 全部 A/B 项打勾 → 把这份清单的勾选状态复制到 Issue #8 评论
+2. JIRA OF4AI-10 / OF4AI-11 添加 Server 侧完成评论（草稿见上一轮对话）
+3. 创建 PR：`feat(word): expose 4 table OASP /word Draft tools (closes #8)`
+4. PR 合并后关闭 Issue #8 + 转 OF4AI-10/11 为「完成」
+
+---
+
+**最后更新**：2026-04-30
+**维护者**：JQQ &lt;jqq1716@gmail.com&gt;

--- a/manual_tests/word/test_helpers.py
+++ b/manual_tests/word/test_helpers.py
@@ -327,6 +327,186 @@ async def replace_selection(
         return observation.success if observation else False
 
 
+async def insert_table(
+    workspace: OfficeWorkspace,
+    document_uri: str,
+    rows: int,
+    columns: int,
+    data: list[list[str]] | None = None,
+    style: str | None = None,
+    insert_location: str | None = None,
+    wait_seconds: int = 3,
+) -> tuple[bool, dict | None, str | None]:
+    """插入表格。"""
+    print(f"\n📝 插入表格: rows={rows}, columns={columns}, insert_location={insert_location}")
+    options: dict[str, Any] = {"rows": rows, "columns": columns}
+    if data is not None:
+        options["data"] = data
+    if style is not None:
+        options["style"] = style
+    if insert_location is not None:
+        options["insertLocation"] = insert_location
+
+    action = OfficeAction(
+        category="word",
+        action_name="insert:table",
+        params={"document_uri": document_uri, "options": options},
+    )
+    result = await workspace.execute(action)
+    if result.success:
+        print(f"✅ 插入表格成功: {result.data}")
+    else:
+        print(f"❌ 插入表格失败: {result.error}")
+
+    print(f"\n⏳ 等待 {wait_seconds} 秒...")
+    await asyncio.sleep(wait_seconds)
+    return result.success, result.data, result.error
+
+
+async def merge_cells(
+    workspace: OfficeWorkspace,
+    document_uri: str,
+    start_row_index: int,
+    start_column_index: int,
+    end_row_index: int,
+    end_column_index: int,
+    table_id: str | None = None,
+    wait_seconds: int = 2,
+) -> tuple[bool, dict | None, str | None]:
+    """合并表格单元格 (OASP /word Draft, v0.2.0)。"""
+    print(
+        f"\n📝 合并单元格: tableId={table_id} "
+        f"({start_row_index},{start_column_index}) → ({end_row_index},{end_column_index})"
+    )
+    params: dict[str, Any] = {
+        "document_uri": document_uri,
+        "start_row_index": start_row_index,
+        "start_column_index": start_column_index,
+        "end_row_index": end_row_index,
+        "end_column_index": end_column_index,
+    }
+    if table_id is not None:
+        params["table_id"] = table_id
+
+    action = OfficeAction(
+        category="word",
+        action_name="merge:cells",
+        params=params,
+    )
+    result = await workspace.execute(action)
+    if result.success:
+        print(f"✅ 合并成功: {result.data}")
+    else:
+        print(f"❌ 合并失败: {result.error}")
+
+    print(f"\n⏳ 等待 {wait_seconds} 秒...")
+    await asyncio.sleep(wait_seconds)
+    return result.success, result.data, result.error
+
+
+async def update_table_cell(
+    workspace: OfficeWorkspace,
+    document_uri: str,
+    cells: list[dict],
+    table_id: str | None = None,
+    wait_seconds: int = 2,
+) -> tuple[bool, dict | None, str | None]:
+    """更新表格单元格的文本和/或格式 (OASP /word Draft, v0.2.0)。"""
+    print(f"\n📝 更新单元格: tableId={table_id}, cells={len(cells)}")
+    params: dict[str, Any] = {"document_uri": document_uri, "cells": cells}
+    if table_id is not None:
+        params["table_id"] = table_id
+
+    action = OfficeAction(
+        category="word",
+        action_name="update:tableCell",
+        params=params,
+    )
+    result = await workspace.execute(action)
+    if result.success:
+        print(f"✅ 更新单元格成功: {result.data}")
+    else:
+        print(f"❌ 更新单元格失败: {result.error}")
+
+    print(f"\n⏳ 等待 {wait_seconds} 秒...")
+    await asyncio.sleep(wait_seconds)
+    return result.success, result.data, result.error
+
+
+async def update_table_row_column(
+    workspace: OfficeWorkspace,
+    document_uri: str,
+    rows: list[dict] | None = None,
+    columns: list[dict] | None = None,
+    table_id: str | None = None,
+    wait_seconds: int = 2,
+) -> tuple[bool, dict | None, str | None]:
+    """按行/列批量写入表格文本 (OASP /word Draft, v0.2.0)。"""
+    print(f"\n📝 批量行/列写入: tableId={table_id}, rows={len(rows or [])}, columns={len(columns or [])}")
+    params: dict[str, Any] = {"document_uri": document_uri}
+    if table_id is not None:
+        params["table_id"] = table_id
+    if rows is not None:
+        params["rows"] = rows
+    if columns is not None:
+        params["columns"] = columns
+
+    action = OfficeAction(
+        category="word",
+        action_name="update:tableRowColumn",
+        params=params,
+    )
+    result = await workspace.execute(action)
+    if result.success:
+        print(f"✅ 批量写入成功: {result.data}")
+    else:
+        print(f"❌ 批量写入失败: {result.error}")
+
+    print(f"\n⏳ 等待 {wait_seconds} 秒...")
+    await asyncio.sleep(wait_seconds)
+    return result.success, result.data, result.error
+
+
+async def update_table_format(
+    workspace: OfficeWorkspace,
+    document_uri: str,
+    table_id: str | None = None,
+    style_options: dict | None = None,
+    border_options: dict | None = None,
+    column_widths: list[float] | None = None,
+    alignment: str | None = None,
+    wait_seconds: int = 2,
+) -> tuple[bool, dict | None, str | None]:
+    """更新整表格式 (OASP /word Draft, v0.2.0)。"""
+    print(f"\n📝 更新整表格式: tableId={table_id}, alignment={alignment}, columnWidths={column_widths}")
+    params: dict[str, Any] = {"document_uri": document_uri}
+    if table_id is not None:
+        params["table_id"] = table_id
+    if style_options is not None:
+        params["style_options"] = style_options
+    if border_options is not None:
+        params["border_options"] = border_options
+    if column_widths is not None:
+        params["column_widths"] = column_widths
+    if alignment is not None:
+        params["alignment"] = alignment
+
+    action = OfficeAction(
+        category="word",
+        action_name="update:tableFormat",
+        params=params,
+    )
+    result = await workspace.execute(action)
+    if result.success:
+        print(f"✅ 更新表格格式成功: {result.data}")
+    else:
+        print(f"❌ 更新表格格式失败: {result.error}")
+
+    print(f"\n⏳ 等待 {wait_seconds} 秒...")
+    await asyncio.sleep(wait_seconds)
+    return result.success, result.data, result.error
+
+
 async def replace_text(
     workspace: OfficeWorkspace,
     document_uri: str,

--- a/manual_tests/word/test_word_table_e2e.py
+++ b/manual_tests/word/test_word_table_e2e.py
@@ -1,0 +1,596 @@
+"""
+Word Table Operations End-to-End Test (OASP /word Draft, v0.2.0)
+
+针对 Issue #8 验收：在真实 Word 文档 + office-editor4ai Add-In 环境下，
+依次驱动 4 个新表格 MCP 工具，并用 python-docx 双重验证 OOXML 结构。
+
+覆盖的 Issue #8 手工测试清单项（自动化部分）：
+- ✅ 端到端连通性（list_tools 已在 unit + integration 测试覆盖；本脚本验证 4 个事件实际能 emit）
+- ✅ word_merge_cells 视觉（合并 5×4 表首行，OOXML 验证合并 span）
+- ✅ word_update_table_cell 视觉（设置首行蓝底白字加粗居中表头）
+- ✅ word_update_table_row_column 视觉（按行批量写入 4 行数据）
+- ✅ word_update_table_format 视觉（边框 + 列宽 + 整表对齐 + 内边距）
+- ✅ tableId 缺省命中（执行不传 tableId 的合并，由 Add-In 解析光标所在表格）
+
+需要人工验证（保留在 docs/manual_tests/word_table_v0.2.0.md 清单中）：
+- ❌ 3013 NO_TABLE_AT_CURSOR（需手工把光标移到普通段落）
+- ❌ 3010 ELEMENT_NOT_FOUND（需手工用超界 tableId）
+- ❌ 3014 ALREADY_MERGED（需手工触发已合并冲突）
+- ❌ AI 业务闭环（合同表头场景，需对接真实 LLM 工具调用）
+
+运行方式：
+    # 健康检查（不需要 Add-In）
+    uv run python manual_tests/word/test_word_table_e2e.py --mode health
+
+    # 端到端表格场景（需要 Add-In + macOS Word，文件保留供你目测）
+    uv run python manual_tests/word/test_word_table_e2e.py --mode tables
+
+成功后，工作副本保留在 manual_tests/.test_working/ 下，用 Word 打开它人眼检查"蓝底
+表头 + 灰底标签 + 列宽合理 + 边框样式"等视觉效果。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make this script runnable both as `python -m` and as a path
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from manual_tests.e2e_base import (  # noqa: E402
+    DocumentReader,
+    E2ETestRunner,
+    create_empty_docx,
+)
+from manual_tests.word.test_helpers import (  # noqa: E402
+    insert_table,
+    merge_cells,
+    update_table_cell,
+    update_table_format,
+    update_table_row_column,
+)
+
+# ============================================================================
+# Fixture preparation
+# ============================================================================
+
+FIXTURES_DIR = _PROJECT_ROOT / "manual_tests" / "fixtures"
+
+
+def ensure_empty_fixture() -> Path:
+    """确保 empty.docx 夹具存在。"""
+    FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    empty_path = FIXTURES_DIR / "empty.docx"
+    if not empty_path.exists():
+        print(f"📝 创建夹具: {empty_path}")
+        create_empty_docx(empty_path)
+    return empty_path
+
+
+# ============================================================================
+# OOXML-level verification via python-docx
+# ============================================================================
+
+
+def _table_grid_widths_emu(reader: DocumentReader, table_index: int = 0) -> list[int]:
+    """读取表格的 tblGrid 列宽（EMU 单位，1 pt = 20 EMU dxa twips ≈ 1/20 of a point in dxa）。
+
+    python-docx 暴露 tblGrid 子元素，宽度以 dxa（twentieths of a point）保存。
+    """
+    table = reader.doc.tables[table_index]
+    grid = table._tbl.tblGrid  # type: ignore[attr-defined]
+    return [int(col.w) for col in grid.gridCol_lst]
+
+
+def _cell_shading_hex(reader: DocumentReader, table_index: int, row: int, col: int) -> str | None:
+    """读取单元格背景色 (w:shd@w:fill)，返回如 '#1F4E79' 或 None。"""
+    table = reader.doc.tables[table_index]
+    cell = table.cell(row, col)
+    tc_pr = cell._tc.tcPr  # type: ignore[attr-defined]
+    if tc_pr is None:
+        return None
+    shd = tc_pr.find("{http://schemas.openxmlformats.org/wordprocessingml/2006/main}shd")
+    if shd is None:
+        return None
+    fill = shd.get("{http://schemas.openxmlformats.org/wordprocessingml/2006/main}fill")
+    if not fill or fill in ("auto", ""):
+        return None
+    return f"#{fill.upper()}"
+
+
+def _is_first_row_merged(reader: DocumentReader, table_index: int = 0) -> bool:
+    """判断首行是否被合并（首行所有单元格的底层 _tc 是否指向同一个 tc）。"""
+    table = reader.doc.tables[table_index]
+    if not table.rows:
+        return False
+    first_row_cells = table.rows[0].cells
+    if len(first_row_cells) <= 1:
+        return False
+    first_tc = first_row_cells[0]._tc  # type: ignore[attr-defined]
+    return all(c._tc is first_tc for c in first_row_cells[1:])  # type: ignore[attr-defined]
+
+
+def verify_table_state_after_pipeline(reader: DocumentReader) -> tuple[bool, list[str]]:
+    """
+    验证经过 4 个表格工具流水线后的 OOXML 结构。
+
+    流水线后预期：
+    - 文档至少 1 张表
+    - 首行被合并（merge_cells 效果）
+    - 首行（合并后）单元格背景色 = #1F4E79（update_table_cell 效果）
+    - 第 2 行第 0 列含"甲方" / 第 2 行第 1 列含"ACME Corp"（update_table_row_column 效果）
+    - 列宽数量 = 4（update_table_format columnWidths=[120,80,80,80] 效果）
+    """
+    messages: list[str] = []
+    success = True
+
+    if reader.table_count < 1:
+        messages.append(f"❌ 表格数 {reader.table_count}，至少应有 1 张")
+        return False, messages
+    messages.append(f"✅ 表格数 = {reader.table_count}")
+
+    if _is_first_row_merged(reader, table_index=0):
+        messages.append("✅ 首行已合并 (merge_cells)")
+    else:
+        messages.append("❌ 首行未合并，merge_cells 效果未生效")
+        success = False
+
+    bg = _cell_shading_hex(reader, table_index=0, row=0, col=0)
+    if bg == "#1F4E79":
+        messages.append(f"✅ 首行单元格背景色 = {bg} (update_table_cell)")
+    else:
+        messages.append(f"❌ 首行单元格背景色 = {bg!r}, 预期 #1F4E79")
+        success = False
+
+    table = reader.doc.tables[0]
+    # 第 2 行 (rowIndex=1) 文本应包含 "甲方" / "ACME Corp"
+    try:
+        row1_texts = [c.text.strip() for c in table.rows[1].cells]
+        if "甲方" in row1_texts[0] and "ACME" in row1_texts[1]:
+            messages.append(f"✅ 第 2 行文本 = {row1_texts[:2]} (update_table_row_column)")
+        else:
+            messages.append(f"❌ 第 2 行文本 = {row1_texts[:2]}，预期含 '甲方' + 'ACME'")
+            success = False
+    except IndexError:
+        messages.append("❌ 表格行数不足，无法读取第 2 行")
+        success = False
+
+    widths = _table_grid_widths_emu(reader, table_index=0)
+    if len(widths) == 4:
+        messages.append(f"✅ tblGrid 列数 = 4，宽度 (dxa) = {widths} (update_table_format)")
+    else:
+        messages.append(f"❌ tblGrid 列数 = {len(widths)}，预期 4")
+        success = False
+
+    return success, messages
+
+
+# ============================================================================
+# Pipelines
+# ============================================================================
+
+
+HEADER_FORMAT: dict[str, Any] = {
+    "horizontalAlignment": "Centered",
+    "verticalAlignment": "Center",
+    "backgroundColor": "#1F4E79",
+    "fontColor": "#FFFFFF",
+    "bold": True,
+}
+
+LABEL_FORMAT: dict[str, Any] = {
+    "backgroundColor": "#EEEEEE",
+    "bold": True,
+}
+
+
+async def run_table_pipeline(workspace: Any, document_uri: str) -> tuple[bool, list[str]]:
+    """4-tool 流水线（已根据 Word.js API 限制重排序）：
+
+    顺序：insert → format(columnWidths) → merge → update_table_cell(header)
+        → update_table_row_column(rows) → update_table_cell(labels) → format(borders+alignment+padding)
+
+    关键：`columnWidths` 必须在 `merge_cells` 之前应用 —— Word.js `TableColumnCollection`
+    在含合并单元格的表上不可访问，是 API 级硬限制
+    （见 office-editor4ai PR #31 / office-editor4ai#29 修复说明）。
+    其它格式（borders / alignment / cellPadding / styleOptions）在合并表上仍可用。
+    """
+    log: list[str] = []
+
+    # 1. insert_table 5×4
+    ok, _, err = await insert_table(
+        workspace,
+        document_uri,
+        rows=5,
+        columns=4,
+        insert_location="End",
+    )
+    if not ok:
+        log.append(f"insert_table 失败: {err}")
+        return False, log
+    log.append("insert_table 5×4 OK")
+
+    # 2. update_table_format(columnWidths) —— 必须在 merge 之前
+    ok, _, err = await update_table_format(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        column_widths=[120, 80, 80, 80],
+    )
+    if not ok:
+        log.append(f"update_table_format(columnWidths) 失败: {err}")
+        return False, log
+    log.append("update_table_format(columnWidths) OK (在 merge 之前)")
+
+    # 3. merge_cells: 首行 4 列 → 1 个合并单元格
+    ok, _, err = await merge_cells(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        start_row_index=0,
+        start_column_index=0,
+        end_row_index=0,
+        end_column_index=3,
+    )
+    if not ok:
+        log.append(f"merge_cells 失败: {err}")
+        return False, log
+    log.append("merge_cells 首行 OK")
+
+    # 4. update_table_cell: 设置首行表头样式 + 文本
+    ok, _, err = await update_table_cell(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        cells=[
+            {
+                "rowIndex": 0,
+                "columnIndex": 0,
+                "text": "甲方信息",
+                "format": HEADER_FORMAT,
+            }
+        ],
+    )
+    if not ok:
+        log.append(f"update_table_cell 表头 失败: {err}")
+        return False, log
+    log.append("update_table_cell 表头 OK")
+
+    # 5. update_table_row_column: 4 行标签/值
+    ok, _, err = await update_table_row_column(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        rows=[
+            {"rowIndex": 1, "values": ["甲方", "ACME Corp", "", ""]},
+            {"rowIndex": 2, "values": ["地址", "上海市浦东新区", "", ""]},
+            {"rowIndex": 3, "values": ["联系人", "张三", "", ""]},
+            {"rowIndex": 4, "values": ["日期", "2026-04-30", "", ""]},
+        ],
+    )
+    if not ok:
+        log.append(f"update_table_row_column 失败: {err}")
+        return False, log
+    log.append("update_table_row_column 4 rows OK")
+
+    # 6. 给标签列加灰底加粗
+    ok, _, err = await update_table_cell(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        cells=[
+            {"rowIndex": 1, "columnIndex": 0, "format": LABEL_FORMAT},
+            {"rowIndex": 2, "columnIndex": 0, "format": LABEL_FORMAT},
+            {"rowIndex": 3, "columnIndex": 0, "format": LABEL_FORMAT},
+            {"rowIndex": 4, "columnIndex": 0, "format": LABEL_FORMAT},
+        ],
+    )
+    if not ok:
+        log.append(f"update_table_cell 标签列 失败: {err}")
+        return False, log
+    log.append("update_table_cell 标签列 OK")
+
+    # 7. update_table_format: 边框 + 内边距 + 整表居中（不含 columnWidths，已在第 2 步设置）
+    ok, _, err = await update_table_format(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        style_options={
+            "cellPadding": {"top": 4, "bottom": 4, "left": 6, "right": 6},
+        },
+        border_options={
+            "location": "all",
+            "style": "Single",
+            "width": 0.5,
+        },
+        alignment="Centered",
+    )
+    if not ok:
+        log.append(f"update_table_format(borders/alignment/padding) 失败: {err}")
+        return False, log
+    log.append("update_table_format(borders+alignment+padding) OK")
+
+    return True, log
+
+
+async def run_error_code_scenarios(workspace: Any, document_uri: str) -> tuple[bool, list[str]]:
+    """B.2 + B.3 错误码场景自动触发。
+
+    需要先跑过 `run_table_pipeline`，文档当前状态：5×4 表，首行已合并。
+
+    自动场景：
+    - B.2: 不存在的 tableId → 3010 ELEMENT_NOT_FOUND
+    - B.3: 合并冲突（在已合并区域上发起相交但不一致的合并）→ 3014 ALREADY_MERGED
+
+    手工场景（仍需在 Word 中点击表格外的段落）：
+    - B.1: 缺省 tableId + 光标不在表格内 → 3013 NO_TABLE_AT_CURSOR
+    """
+    log: list[str] = []
+    all_ok = True
+
+    # B.2: tableId not found → 3010
+    log.append("--- B.2 不存在的 tableId → 3010 ELEMENT_NOT_FOUND ---")
+    ok, _, err = await update_table_cell(
+        workspace,
+        document_uri,
+        table_id="table-99",
+        cells=[{"rowIndex": 0, "columnIndex": 0, "text": "x"}],
+        wait_seconds=1,
+    )
+    if ok:
+        log.append("  ❌ B.2 预期失败但成功了")
+        all_ok = False
+    elif err and "3010" in err:
+        log.append(f"  ✅ B.2 错误码包含 3010: {err[:80]}")
+    else:
+        log.append(f"  ⚠️  B.2 失败但错误码不是 3010: {err}")
+        all_ok = False
+
+    # B.3: merge conflict → 3014
+    # 当前状态：首行 (0,0)-(0,3) 已合并；再发一个相交但不一致的合并 (0,0)-(1,2)
+    log.append("--- B.3 合并冲突 → 3014 ALREADY_MERGED ---")
+    ok, _, err = await merge_cells(
+        workspace,
+        document_uri,
+        table_id="table-0",
+        start_row_index=0,
+        start_column_index=0,
+        end_row_index=1,
+        end_column_index=2,
+        wait_seconds=1,
+    )
+    if ok:
+        log.append("  ❌ B.3 预期失败但成功了")
+        all_ok = False
+    elif err and "3014" in err:
+        log.append(f"  ✅ B.3 错误码包含 3014: {err[:80]}")
+    else:
+        log.append(f"  ⚠️  B.3 失败但错误码不是 3014: {err}")
+        all_ok = False
+
+    log.append("--- B.1 (3013 NO_TABLE_AT_CURSOR) 需在 Word 中手工触发 ---")
+    log.append("  手工步骤：")
+    log.append("    1) 在 Word 中点击表格之外的某个段落，让光标离开表格")
+    log.append("    2) 重跑：uv run python manual_tests/word/test_word_table_e2e.py --mode b1")
+    log.append("    3) 预期：错误码包含 3013")
+
+    return all_ok, log
+
+
+async def test_b1_cursor_outside_table() -> bool:
+    """B.1 单独场景：缺省 tableId + 光标不在表格内 → 3013 NO_TABLE_AT_CURSOR.
+
+    前置：用户已在 Word 中打开文档（含至少 1 张表）+ 光标点在表格之外的段落。
+    """
+    print("\n" + "=" * 70)
+    print("🧪 B.1 — 缺省 tableId + 光标不在表格内 → 3013")
+    print("=" * 70)
+    print("\n📌 前置：请确保 Word 文档已开 + 光标点在表格之外的段落。\n")
+
+    from manual_tests.word.test_helpers import ready_workspace
+
+    try:
+        async with ready_workspace(host="127.0.0.1", port=3000) as (workspace, doc_uri):
+            print(f"📂 当前文档: {doc_uri}\n")
+            ok, _, err = await merge_cells(
+                workspace,
+                doc_uri,
+                start_row_index=0,
+                start_column_index=0,
+                end_row_index=0,
+                end_column_index=2,
+                wait_seconds=1,
+            )
+            if ok:
+                print("\n❌ B.1 预期失败但成功了 — 光标可能仍在表格内")
+                return False
+            if err and "3013" in err:
+                print(f"\n✅ B.1 错误码包含 3013: {err[:120]}")
+                return True
+            print(f"\n⚠️  B.1 失败但错误码不是 3013: {err}")
+            return False
+    except Exception as exc:
+        print(f"\n❌ B.1 测试中断: {exc}")
+        return False
+
+
+async def run_omitted_table_id_smoke(workspace: Any, document_uri: str) -> tuple[bool, list[str]]:
+    """缺省 tableId 路径冒烟：依赖光标当前位于上一步插入的表格内。
+
+    Add-In 在 PR #27 实装后，缺省 tableId 时应解析光标所在表格。本步骤
+    在已经修改完表格的情况下再发一次合并请求验证缺省路径不报错。
+    """
+    log: list[str] = []
+    print("\n📌 提示：请确保光标停留在表格内（脚本不操控光标）。\n")
+    await asyncio.sleep(2)
+
+    # 让 Add-In 自行决定要操作的表 — 这里我们用一个安全的 no-op-ish 操作：
+    # 在已合并的首行单独发一次 update_table_cell（不带 table_id），
+    # 仅用于验证 wire payload 中 tableId 缺失，且 Add-In 能正常 ack。
+    ok, data, err = await update_table_cell(
+        workspace,
+        document_uri,
+        cells=[
+            {
+                "rowIndex": 0,
+                "columnIndex": 0,
+                "format": {"bold": True},
+            }
+        ],
+    )
+    if ok:
+        log.append(f"omitted-tableId update_table_cell OK, data={data}")
+    else:
+        log.append(f"omitted-tableId update_table_cell 失败: {err}")
+        # 这一步可能因为光标不在表内而报 3013，视为提示而非硬失败
+    return ok, log
+
+
+# ============================================================================
+# Top-level scenarios
+# ============================================================================
+
+
+async def test_workspace_health() -> bool:
+    """快速健康检查：验证 Workspace 启动 / 工具注册。"""
+    from office4ai.environment.workspace.office_workspace import OfficeWorkspace
+
+    print("\n" + "=" * 70)
+    print("🏥 Workspace Health Check (4 new table tools)")
+    print("=" * 70)
+
+    workspace = OfficeWorkspace(host="127.0.0.1", port=3000)
+    try:
+        await workspace.start()
+        print("✅ Workspace 运行正常")
+        # 列出 Workspace 自身知道的事件，确认 4 个新事件已注册到 DTO 注册表
+        from office4ai.environment.workspace.dtos.common import request_registry
+
+        events = request_registry.all_events()
+        new_events = [
+            "word:merge:cells",
+            "word:update:tableCell",
+            "word:update:tableRowColumn",
+            "word:update:tableFormat",
+        ]
+        missing = [e for e in new_events if e not in events]
+        if missing:
+            print(f"❌ 以下事件未注册: {missing}")
+            return False
+        print(f"✅ 4 个新表格事件均已注册到 request_registry: {new_events}")
+        return True
+    except Exception as exc:
+        print(f"❌ 健康检查失败: {exc}")
+        return False
+    finally:
+        await workspace.stop()
+
+
+async def test_word_table_e2e() -> bool:
+    """端到端表格流水线：插表 → 合并 → 表头 → 行写入 → 整表格式 → OOXML 验证。"""
+    print("\n" + "=" * 70)
+    print("🧪 Word Table E2E Test (OASP /word Draft, v0.2.0)")
+    print("=" * 70)
+
+    ensure_empty_fixture()
+
+    runner = E2ETestRunner(
+        fixtures_dir=FIXTURES_DIR,
+        host="127.0.0.1",
+        port=3000,
+        connection_timeout=30.0,
+        auto_open=True,
+        auto_close=False,  # 让用户视觉验证后再手动关闭
+        auto_activate=True,
+        cleanup_on_success=False,  # 保留工作副本，便于 Word 中目测
+    )
+
+    try:
+        async with runner.run_with_workspace("empty.docx", open_delay=3.0) as (workspace, fixture):
+            print(f"\n📂 测试工作副本: {fixture.working_path}")
+
+            # Phase 1: 4-tool pipeline
+            ok, pipe_log = await run_table_pipeline(workspace, fixture.document_uri)
+            for line in pipe_log:
+                print(f"  • {line}")
+            if not ok:
+                print("\n❌ Pipeline 中断；保留工作副本供调试。")
+                return False
+
+            # Phase 2: omitted tableId smoke (软性，不计入硬失败 — 取决于光标位置)
+            _, omit_log = await run_omitted_table_id_smoke(workspace, fixture.document_uri)
+            for line in omit_log:
+                print(f"  • {line}")
+
+            # Phase 3: OOXML verification
+            print("\n📊 OOXML 结构验证 (需要 Word 已保存到磁盘)...")
+            await asyncio.sleep(1.5)
+            reader = DocumentReader(fixture.working_path)
+            reader.reload()  # 触发 AppleScript save
+            verified, messages = verify_table_state_after_pipeline(reader)
+            for msg in messages:
+                print(f"  {msg}")
+
+            # Phase 4: B.2 + B.3 错误码场景（B.1 因依赖光标位置另起 --mode b1）
+            print("\n🚨 错误码场景（B.2 + B.3 自动触发）...")
+            err_ok, err_log = await run_error_code_scenarios(workspace, fixture.document_uri)
+            for line in err_log:
+                print(f"  {line}")
+
+            all_ok = verified and err_ok
+            print("\n" + "=" * 70)
+            if all_ok:
+                print("✅ E2E 表格流水线 + 错误码 B.2/B.3 全部通过；请打开下面文件目测视觉效果：")
+            else:
+                print("❌ 部分检查未通过；保留工作副本供调试：")
+            print(f"   {fixture.working_path}")
+            print("=" * 70)
+            return all_ok
+    except Exception as exc:
+        print(f"\n❌ 测试中断: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+# ============================================================================
+# CLI entry
+# ============================================================================
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Word Table E2E Tests (OASP /word Draft, v0.2.0)")
+    parser.add_argument(
+        "--mode",
+        choices=["health", "tables", "b1"],
+        default="health",
+        help=(
+            "health: 快速校验 4 个事件已注册；"
+            "tables: 完整端到端表格流水线 (含 B.2/B.3 错误码自动触发，需要 Add-In + Word)；"
+            "b1: B.1 单独场景 (光标不在表格内 → 3013，需先在 Word 中点击表格外段落)"
+        ),
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.mode == "health":
+            success = asyncio.run(test_workspace_health())
+        elif args.mode == "b1":
+            success = asyncio.run(test_b1_cursor_outside_table())
+        else:
+            success = asyncio.run(test_word_table_e2e())
+        sys.exit(0 if success else 1)
+    except KeyboardInterrupt:
+        print("\n\n⏸️  测试被用户中断")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/office4ai/a2c_smcp/tools/word/__init__.py
+++ b/office4ai/a2c_smcp/tools/word/__init__.py
@@ -16,11 +16,15 @@ from office4ai.a2c_smcp.tools.word.insert_image import WordInsertImageTool
 from office4ai.a2c_smcp.tools.word.insert_table import WordInsertTableTool
 from office4ai.a2c_smcp.tools.word.insert_text import WordInsertTextTool
 from office4ai.a2c_smcp.tools.word.insert_toc import WordInsertTOCTool
+from office4ai.a2c_smcp.tools.word.merge_cells import WordMergeCellsTool
 from office4ai.a2c_smcp.tools.word.replace_selection import WordReplaceSelectionTool
 from office4ai.a2c_smcp.tools.word.replace_text import WordReplaceTextTool
 from office4ai.a2c_smcp.tools.word.reply_comment import WordReplyCommentTool
 from office4ai.a2c_smcp.tools.word.resolve_comment import WordResolveCommentTool
 from office4ai.a2c_smcp.tools.word.select_text import WordSelectTextTool
+from office4ai.a2c_smcp.tools.word.update_table_cell import WordUpdateTableCellTool
+from office4ai.a2c_smcp.tools.word.update_table_format import WordUpdateTableFormatTool
+from office4ai.a2c_smcp.tools.word.update_table_row_column import WordUpdateTableRowColumnTool
 
 __all__ = [
     # Get tools
@@ -41,6 +45,11 @@ __all__ = [
     "WordInsertTableTool",
     "WordInsertEquationTool",
     "WordInsertTOCTool",
+    # Table operation tools (OASP /word Draft, v0.2.0)
+    "WordMergeCellsTool",
+    "WordUpdateTableCellTool",
+    "WordUpdateTableRowColumnTool",
+    "WordUpdateTableFormatTool",
     # Export tool
     "WordExportContentTool",
     # Comment tools

--- a/office4ai/a2c_smcp/tools/word/merge_cells.py
+++ b/office4ai/a2c_smcp/tools/word/merge_cells.py
@@ -1,0 +1,81 @@
+"""word_merge_cells MCP Tool (OASP /word Draft, v0.2.0)"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+
+
+class WordMergeCellsInput(BaseModel):
+    """MCP 输入模型: 合并 Word 表格中的矩形单元格区域"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/doc.docx)")
+    table_id: str | None = Field(
+        default=None,
+        description=(
+            "Target table identifier (e.g. 'table-0'). "
+            "Omit to target the table containing the current cursor; "
+            "if the cursor is not inside a table, the operation fails with 3013 NO_TABLE_AT_CURSOR."
+        ),
+    )
+    start_row_index: int = Field(
+        ...,
+        description="Start row index (0-based, inclusive)",
+        ge=0,
+    )
+    start_column_index: int = Field(
+        ...,
+        description="Start column index (0-based, inclusive)",
+        ge=0,
+    )
+    end_row_index: int = Field(
+        ...,
+        description="End row index (0-based, inclusive)",
+        ge=0,
+    )
+    end_column_index: int = Field(
+        ...,
+        description="End column index (0-based, inclusive)",
+        ge=0,
+    )
+
+
+class WordMergeCellsTool(BaseTool):
+    """Merge a rectangular range of cells in a Word table (OASP /word Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "word_merge_cells"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Merge a rectangular range of cells in a Word table into a single cell "
+            "(OASP /word Draft). "
+            "Specify the inclusive (startRowIndex, startColumnIndex) and (endRowIndex, endColumnIndex) "
+            "to delimit the region. "
+            "Typical use: turn the first row of a table into a single full-width header cell "
+            "(e.g. for contract / report headings such as 'Party A Information'). "
+            "tableId is optional — when omitted, the Add-In targets the table containing the cursor; "
+            "if the cursor is not inside a table, the call fails with 3013 NO_TABLE_AT_CURSOR. "
+            "Conflicts with existing merged regions raise 3014 ALREADY_MERGED."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return WordMergeCellsInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "word"
+
+    @property
+    def event_name(self) -> str:
+        return "merge:cells"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return WordMergeCellsInput

--- a/office4ai/a2c_smcp/tools/word/update_table_cell.py
+++ b/office4ai/a2c_smcp/tools/word/update_table_cell.py
@@ -1,0 +1,73 @@
+"""word_update_table_cell MCP Tool (OASP /word Draft, v0.2.0)"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.dtos.word import TableCellUpdate
+
+
+class WordUpdateTableCellInput(BaseModel):
+    """MCP 输入模型: 更新 Word 表格中指定单元格的文本和/或格式"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/doc.docx)")
+    table_id: str | None = Field(
+        default=None,
+        description=(
+            "Target table identifier (e.g. 'table-0'). "
+            "Omit to target the table containing the current cursor; "
+            "if the cursor is not inside a table, the operation fails with 3013 NO_TABLE_AT_CURSOR."
+        ),
+    )
+    cells: list[TableCellUpdate] = Field(
+        ...,
+        description=(
+            "Cells to update. Each entry needs rowIndex / columnIndex and at least one of "
+            "text / format. format supports backgroundColor, fontName, fontSize, fontColor, "
+            "bold, italic, horizontalAlignment ('Left' | 'Centered' | 'Right' | 'Justified'), "
+            "verticalAlignment ('Top' | 'Center' | 'Bottom')."
+        ),
+        min_length=1,
+    )
+
+
+class WordUpdateTableCellTool(BaseTool):
+    """Update specific cells in a Word table (OASP /word Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "word_update_table_cell"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Update specific cells in a Word table — text and/or format "
+            "(OASP /word Draft). "
+            "Each cell is addressed by (rowIndex, columnIndex) and may set new text, "
+            "background color, font, alignment, etc. "
+            "Use this to apply per-cell visual effects such as a blue-bg centered bold "
+            "header cell or alternating gray label / white input cells. "
+            "tableId is optional — when omitted, the Add-In targets the table containing the cursor; "
+            "if the cursor is not inside a table, the call fails with 3013 NO_TABLE_AT_CURSOR. "
+            "Use 'Centered' / 'Justified' (NOT 'Center' / 'Justify') for horizontalAlignment, "
+            "and 'Center' (NOT 'Middle') for verticalAlignment, per Word.Alignment enum."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return WordUpdateTableCellInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "word"
+
+    @property
+    def event_name(self) -> str:
+        return "update:tableCell"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return WordUpdateTableCellInput

--- a/office4ai/a2c_smcp/tools/word/update_table_format.py
+++ b/office4ai/a2c_smcp/tools/word/update_table_format.py
@@ -1,0 +1,92 @@
+"""word_update_table_format MCP Tool (OASP /word Draft, v0.2.0)"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.dtos.word import (
+    TableBorderOptions,
+    TableStyleOptions,
+)
+
+
+class WordUpdateTableFormatInput(BaseModel):
+    """MCP 输入模型: 更新 Word 整表格式（样式、边框、列宽、对齐、内边距）"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/doc.docx)")
+    table_id: str | None = Field(
+        default=None,
+        description=(
+            "Target table identifier (e.g. 'table-0'). "
+            "Omit to target the table containing the current cursor; "
+            "if the cursor is not inside a table, the operation fails with 3013 NO_TABLE_AT_CURSOR."
+        ),
+    )
+    style_options: TableStyleOptions | None = Field(
+        default=None,
+        description=(
+            "Style preset (styleType, firstColumn, lastColumn, totalRow, bandedRows, "
+            "bandedColumns) plus table-level cellPadding (top/bottom/left/right). "
+            "An unknown styleType triggers 3011 STYLE_NOT_FOUND."
+        ),
+    )
+    border_options: TableBorderOptions | None = Field(
+        default=None,
+        description=(
+            "Border options: location ('all' | 'inside' | 'outside', default 'all'), "
+            "style ('Single' | 'Double' | 'Dashed' | 'Dotted' | 'None'), "
+            "width (points), color (hex)."
+        ),
+    )
+    column_widths: list[float] | None = Field(
+        default=None,
+        description=(
+            "Column widths in points; length must be ≤ table column count (over-length triggers 4002 INVALID_PARAM)."
+        ),
+    )
+    alignment: Literal["Left", "Centered", "Right"] | None = Field(
+        default=None,
+        description="Whole-table horizontal alignment (Word.Alignment enum: 'Left' | 'Centered' | 'Right').",
+    )
+
+
+class WordUpdateTableFormatTool(BaseTool):
+    """Update overall Word table format — preset, borders, column widths, alignment, padding (OASP /word Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "word_update_table_format"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Update the overall format of a Word table "
+            "(OASP /word Draft). "
+            "Apply a built-in style preset (styleType + bandedRows/firstColumn/...), "
+            "borders (location 'all' | 'inside' | 'outside' + style + width + color), "
+            "column widths in points, whole-table alignment, "
+            "and table-level cell padding via styleOptions.cellPadding. "
+            "Note: this tool does not write cell text — use word_update_table_row_column for that. "
+            "tableId is optional — when omitted, the Add-In targets the table containing the cursor; "
+            "if the cursor is not inside a table, the call fails with 3013 NO_TABLE_AT_CURSOR. "
+            "Use 'Centered' (NOT 'Center') for alignment, per Word.Alignment enum."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return WordUpdateTableFormatInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "word"
+
+    @property
+    def event_name(self) -> str:
+        return "update:tableFormat"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return WordUpdateTableFormatInput

--- a/office4ai/a2c_smcp/tools/word/update_table_row_column.py
+++ b/office4ai/a2c_smcp/tools/word/update_table_row_column.py
@@ -1,0 +1,76 @@
+"""word_update_table_row_column MCP Tool (OASP /word Draft, v0.2.0)"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.dtos.word import TableColumnUpdate, TableRowUpdate
+
+
+class WordUpdateTableRowColumnInput(BaseModel):
+    """MCP 输入模型: 按行/列批量写入 Word 表格文本"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/doc.docx)")
+    table_id: str | None = Field(
+        default=None,
+        description=(
+            "Target table identifier (e.g. 'table-0'). "
+            "Omit to target the table containing the current cursor; "
+            "if the cursor is not inside a table, the operation fails with 3013 NO_TABLE_AT_CURSOR."
+        ),
+    )
+    rows: list[TableRowUpdate] | None = Field(
+        default=None,
+        description="Row updates — each row writes a full sequence of column values",
+    )
+    columns: list[TableColumnUpdate] | None = Field(
+        default=None,
+        description="Column updates — each column writes a full sequence of row values",
+    )
+
+    @model_validator(mode="after")
+    def _ensure_rows_or_columns(self) -> WordUpdateTableRowColumnInput:
+        if not self.rows and not self.columns:
+            raise ValueError("At least one of 'rows' or 'columns' must be provided")
+        return self
+
+
+class WordUpdateTableRowColumnTool(BaseTool):
+    """Batch-update Word table cells by entire row(s) or column(s) (OASP /word Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "word_update_table_row_column"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Batch-write Word table cells by full rows or columns "
+            "(OASP /word Draft). "
+            "Provide rows[] (each row carries values[] for every column) and/or "
+            "columns[] (each column carries values[] for every row). "
+            "Typical use: fill several rows of structured contract / report data "
+            "in a single round-trip. "
+            "tableId is optional — when omitted, the Add-In targets the table containing the cursor; "
+            "if the cursor is not inside a table, the call fails with 3013 NO_TABLE_AT_CURSOR. "
+            "At least one of rows / columns must be supplied."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return WordUpdateTableRowColumnInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "word"
+
+    @property
+    def event_name(self) -> str:
+        return "update:tableRowColumn"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return WordUpdateTableRowColumnInput

--- a/office4ai/environment/workspace/dtos/common.py
+++ b/office4ai/environment/workspace/dtos/common.py
@@ -376,6 +376,9 @@ class ErrorCode:
     ELEMENT_NOT_FOUND = "3010"
     STYLE_NOT_FOUND = "3011"
     SEARCH_NO_MATCH = "3012"
+    NO_TABLE_AT_CURSOR = "3013"
+    ALREADY_MERGED = "3014"
+    OFFICE_API_ERROR = "3999"
 
     # Validation errors (4xxx)
     VALIDATION_ERROR = "4000"

--- a/office4ai/environment/workspace/dtos/word.py
+++ b/office4ai/environment/workspace/dtos/word.py
@@ -1317,6 +1317,479 @@ class WordResolveCommentRequest(BaseRequest):
     )
 
 
+# ============================================================================
+# Table Operation DTOs (OASP /word Draft, v0.2.0)
+#
+# OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+# Data structures: https://doc.turingfocus.cn/oasp/0.2.0/specification/data-structures/
+#
+# 4 events newly published in OASP v0.2.0 (2026-04-30, commit 77d5ffb):
+#   - word:merge:cells
+#   - word:update:tableCell
+#   - word:update:tableRowColumn
+#   - word:update:tableFormat
+#
+# Stability: Draft. DTOs use lenient parsing — extra fields tolerated, optional
+# fields default to None. Pin protocol references to v0.2.0 (NOT main HEAD).
+# ============================================================================
+
+
+class CellFormat(SocketIOBaseModel):
+    """
+    Word table cell formatting options (shared by word:update:tableCell and similar).
+
+    Field names align strictly with Word.Alignment / Word.VerticalAlignment enums:
+      - horizontalAlignment: "Centered" / "Justified" (NOT "Center" / "Justify")
+      - verticalAlignment: "Center" (NOT "Middle")
+
+    Note: cellPadding is NOT in CellFormat — Word.js padding API is table-level,
+    so it lives in UpdateTableFormatRequest.styleOptions.cellPadding.
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/data-structures/
+    """
+
+    horizontal_alignment: Literal["Left", "Centered", "Right", "Justified"] | None = Field(
+        default=None,
+        alias="horizontalAlignment",
+        description="Horizontal alignment (Word.Alignment enum value)",
+    )
+    vertical_alignment: Literal["Top", "Center", "Bottom"] | None = Field(
+        default=None,
+        alias="verticalAlignment",
+        description="Vertical alignment (Word.VerticalAlignment enum value)",
+    )
+    background_color: str | None = Field(
+        default=None,
+        alias="backgroundColor",
+        description="Cell background color (hex, e.g. '#1F4E79')",
+    )
+    font_name: str | None = Field(
+        default=None,
+        alias="fontName",
+        description="Font family name",
+    )
+    font_size: float | None = Field(
+        default=None,
+        alias="fontSize",
+        description="Font size (points), positive number",
+        gt=0,
+    )
+    font_color: str | None = Field(
+        default=None,
+        alias="fontColor",
+        description="Font color (hex)",
+    )
+    bold: bool | None = Field(default=None, alias="bold", description="Bold text")
+    italic: bool | None = Field(default=None, alias="italic", description="Italic text")
+
+
+class TableSummary(SocketIOBaseModel):
+    """
+    Compact summary of a table for word:get:documentStructure response (v0.2.0+).
+
+    Allows AI to re-discover existing tables and mitigate the temporary-index
+    fragility of `tableId` (kept as "table-{i}" until Content Control IDs land
+    via oasp-protocol#3).
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/data-structures/
+    """
+
+    table_id: str = Field(
+        ...,
+        alias="tableId",
+        description="Table identifier (e.g. 'table-0'), iteration order of body.tables",
+    )
+    row_count: int = Field(
+        ...,
+        alias="rowCount",
+        description="Number of rows",
+        ge=0,
+    )
+    column_count: int = Field(
+        ...,
+        alias="columnCount",
+        description="Number of columns",
+        ge=0,
+    )
+    preceding_heading: str | None = Field(
+        default=None,
+        alias="precedingHeading",
+        description="Nearest heading paragraph text preceding this table (heuristic locator)",
+    )
+
+
+# ---------- word:merge:cells ----------
+
+
+class WordMergeCellsRequest(BaseRequest):
+    """
+    Request to merge a rectangular range of cells in a Word table.
+
+    Stability: Draft (OASP /word Draft, v0.2.0). When tableId is omitted,
+    the Add-In resolves it from the current cursor location; if the cursor is
+    not inside a table, the Add-In responds with error 3013 NO_TABLE_AT_CURSOR.
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+    """
+
+    event_name: ClassVar[str] = "word:merge:cells"
+
+    table_id: str | None = Field(
+        default=None,
+        alias="tableId",
+        description="Target table identifier; defaults to the table containing the cursor",
+    )
+    start_row_index: int = Field(
+        ...,
+        alias="startRowIndex",
+        description="Start row index (0-based, inclusive)",
+        ge=0,
+    )
+    start_column_index: int = Field(
+        ...,
+        alias="startColumnIndex",
+        description="Start column index (0-based, inclusive)",
+        ge=0,
+    )
+    end_row_index: int = Field(
+        ...,
+        alias="endRowIndex",
+        description="End row index (0-based, inclusive)",
+        ge=0,
+    )
+    end_column_index: int = Field(
+        ...,
+        alias="endColumnIndex",
+        description="End column index (0-based, inclusive)",
+        ge=0,
+    )
+
+
+class MergeCellsRequestedRange(SocketIOBaseModel):
+    """Dimension summary of the requested merge range."""
+
+    row_count: int = Field(..., alias="rowCount", description="Number of rows merged", ge=0)
+    column_count: int = Field(..., alias="columnCount", description="Number of columns merged", ge=0)
+
+
+class MergeCellsResult(SocketIOBaseModel):
+    """Result for word:merge:cells operation."""
+
+    table_id: str = Field(
+        ...,
+        alias="tableId",
+        description="Table identifier the merge was applied to",
+    )
+    requested_range: MergeCellsRequestedRange = Field(
+        ...,
+        alias="requestedRange",
+        description="Dimensions of the merged region",
+    )
+
+
+class WordMergeCellsResponse(SocketIOBaseModel):
+    """Response for word:merge:cells operation."""
+
+    request_id: str = Field(..., alias="requestId", description="Request ID being responded to")
+    success: bool = Field(..., alias="success", description="Whether the operation succeeded")
+    data: MergeCellsResult | None = Field(default=None, alias="data", description="Merge result")
+    error: Optional["ErrorResponse"] = Field(default=None, alias="error", description="Error details if failed")
+    timestamp: int = Field(..., alias="timestamp", description="Server timestamp in milliseconds")
+
+
+# ---------- word:update:tableCell ----------
+
+
+class TableCellUpdate(SocketIOBaseModel):
+    """
+    Single cell update for word:update:tableCell.
+
+    `text` and `format` are both optional, but at least one must be provided.
+    """
+
+    row_index: int = Field(..., alias="rowIndex", description="Row index (0-based)", ge=0)
+    column_index: int = Field(..., alias="columnIndex", description="Column index (0-based)", ge=0)
+    text: str | None = Field(default=None, alias="text", description="New text content for the cell")
+    format: CellFormat | None = Field(
+        default=None,
+        alias="format",
+        description="Cell-level format (alignment, background, font, ...)",
+    )
+
+
+class WordUpdateTableCellRequest(BaseRequest):
+    """
+    Request to update specific cells in a Word table (text and/or format).
+
+    Stability: Draft (OASP /word Draft, v0.2.0).
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+    """
+
+    event_name: ClassVar[str] = "word:update:tableCell"
+
+    table_id: str | None = Field(
+        default=None,
+        alias="tableId",
+        description="Target table identifier; defaults to the table containing the cursor",
+    )
+    cells: list[TableCellUpdate] = Field(
+        ...,
+        alias="cells",
+        description="Cells to update (at least one)",
+        min_length=1,
+    )
+
+
+class UpdateTableCellResult(SocketIOBaseModel):
+    """Result for word:update:tableCell operation.
+
+    OASP v0.2.0 wire shape: {tableId, cellsUpdated, rowCount, columnCount}.
+    rowCount / columnCount reflect the table's current dimensions after the update.
+    """
+
+    table_id: str = Field(..., alias="tableId", description="Table identifier")
+    cells_updated: int = Field(
+        ...,
+        alias="cellsUpdated",
+        description="Number of cells successfully updated",
+        ge=0,
+    )
+    row_count: int = Field(
+        ...,
+        alias="rowCount",
+        description="Total row count of the table after update",
+        ge=0,
+    )
+    column_count: int = Field(
+        ...,
+        alias="columnCount",
+        description="Total column count of the table after update",
+        ge=0,
+    )
+
+
+class WordUpdateTableCellResponse(SocketIOBaseModel):
+    """Response for word:update:tableCell operation."""
+
+    request_id: str = Field(..., alias="requestId", description="Request ID being responded to")
+    success: bool = Field(..., alias="success", description="Whether the operation succeeded")
+    data: UpdateTableCellResult | None = Field(default=None, alias="data", description="Update result")
+    error: Optional["ErrorResponse"] = Field(default=None, alias="error", description="Error details if failed")
+    timestamp: int = Field(..., alias="timestamp", description="Server timestamp in milliseconds")
+
+
+# ---------- word:update:tableRowColumn ----------
+
+
+class TableRowUpdate(SocketIOBaseModel):
+    """Row-level batch update for word:update:tableRowColumn."""
+
+    row_index: int = Field(..., alias="rowIndex", description="Row index (0-based)", ge=0)
+    values: list[str] = Field(..., alias="values", description="Text values for each column in the row")
+
+
+class TableColumnUpdate(SocketIOBaseModel):
+    """Column-level batch update for word:update:tableRowColumn."""
+
+    column_index: int = Field(..., alias="columnIndex", description="Column index (0-based)", ge=0)
+    values: list[str] = Field(..., alias="values", description="Text values for each row in the column")
+
+
+class WordUpdateTableRowColumnRequest(BaseRequest):
+    """
+    Request to batch-update Word table cells by entire row(s) or column(s).
+
+    Stability: Draft (OASP /word Draft, v0.2.0). Provide `rows`, `columns`, or
+    both; the Add-In writes them in document order.
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+    """
+
+    event_name: ClassVar[str] = "word:update:tableRowColumn"
+
+    table_id: str | None = Field(
+        default=None,
+        alias="tableId",
+        description="Target table identifier; defaults to the table containing the cursor",
+    )
+    rows: list[TableRowUpdate] | None = Field(
+        default=None,
+        alias="rows",
+        description="Row updates (each writes a full row of values)",
+    )
+    columns: list[TableColumnUpdate] | None = Field(
+        default=None,
+        alias="columns",
+        description="Column updates (each writes a full column of values)",
+    )
+
+
+class UpdateTableRowColumnResult(SocketIOBaseModel):
+    """Result for word:update:tableRowColumn operation.
+
+    OASP v0.2.0 wire shape: {tableId, cellsUpdated, rowCount, columnCount}.
+    cellsUpdated is the total cells written across all rows + columns.
+    """
+
+    table_id: str = Field(..., alias="tableId", description="Table identifier")
+    cells_updated: int = Field(
+        ...,
+        alias="cellsUpdated",
+        description="Total cells written across all rows + columns",
+        ge=0,
+    )
+    row_count: int = Field(
+        ...,
+        alias="rowCount",
+        description="Total row count of the table after update",
+        ge=0,
+    )
+    column_count: int = Field(
+        ...,
+        alias="columnCount",
+        description="Total column count of the table after update",
+        ge=0,
+    )
+
+
+class WordUpdateTableRowColumnResponse(SocketIOBaseModel):
+    """Response for word:update:tableRowColumn operation."""
+
+    request_id: str = Field(..., alias="requestId", description="Request ID being responded to")
+    success: bool = Field(..., alias="success", description="Whether the operation succeeded")
+    data: UpdateTableRowColumnResult | None = Field(default=None, alias="data", description="Update result")
+    error: Optional["ErrorResponse"] = Field(default=None, alias="error", description="Error details if failed")
+    timestamp: int = Field(..., alias="timestamp", description="Server timestamp in milliseconds")
+
+
+# ---------- word:update:tableFormat ----------
+
+
+class TableCellPadding(SocketIOBaseModel):
+    """Table-level uniform cell padding (Word.js padding API is table-level)."""
+
+    top: float | None = Field(default=None, alias="top", description="Top padding (points)", ge=0)
+    bottom: float | None = Field(default=None, alias="bottom", description="Bottom padding (points)", ge=0)
+    left: float | None = Field(default=None, alias="left", description="Left padding (points)", ge=0)
+    right: float | None = Field(default=None, alias="right", description="Right padding (points)", ge=0)
+
+
+class TableStyleOptions(SocketIOBaseModel):
+    """Style options for Word table (table-style preset + cellPadding)."""
+
+    style_type: str | None = Field(
+        default=None,
+        alias="styleType",
+        description="Built-in or custom Word table style name (e.g. 'Grid Table 4 - Accent 1')",
+    )
+    first_column: bool | None = Field(default=None, alias="firstColumn", description="Apply first-column style")
+    last_column: bool | None = Field(default=None, alias="lastColumn", description="Apply last-column style")
+    total_row: bool | None = Field(default=None, alias="totalRow", description="Apply total-row style")
+    banded_rows: bool | None = Field(default=None, alias="bandedRows", description="Apply banded-row style")
+    banded_columns: bool | None = Field(default=None, alias="bandedColumns", description="Apply banded-column style")
+    cell_padding: TableCellPadding | None = Field(
+        default=None,
+        alias="cellPadding",
+        description="Table-level uniform cell padding",
+    )
+
+
+class TableBorderOptions(SocketIOBaseModel):
+    """Border options for Word table."""
+
+    location: Literal["all", "inside", "outside"] | None = Field(
+        default=None,
+        alias="location",
+        description="Border location (default: 'all')",
+    )
+    style: Literal["Single", "Double", "Dashed", "Dotted", "None"] | None = Field(
+        default=None,
+        alias="style",
+        description="Border line style",
+    )
+    width: float | None = Field(
+        default=None,
+        alias="width",
+        description="Border width (points), positive number",
+        gt=0,
+    )
+    color: str | None = Field(default=None, alias="color", description="Border color (hex)")
+
+
+class WordUpdateTableFormatRequest(BaseRequest):
+    """
+    Request to update overall Word table format (style preset, borders, column
+    widths, alignment, cell padding).
+
+    Stability: Draft (OASP /word Draft, v0.2.0). Note: the original draft's
+    `data` field has been removed — use word:update:tableRowColumn for cell text.
+
+    OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+    """
+
+    event_name: ClassVar[str] = "word:update:tableFormat"
+
+    table_id: str | None = Field(
+        default=None,
+        alias="tableId",
+        description="Target table identifier; defaults to the table containing the cursor",
+    )
+    style_options: TableStyleOptions | None = Field(
+        default=None,
+        alias="styleOptions",
+        description="Table style preset + table-level cell padding",
+    )
+    border_options: TableBorderOptions | None = Field(
+        default=None,
+        alias="borderOptions",
+        description="Border location/style/width/color",
+    )
+    column_widths: list[float] | None = Field(
+        default=None,
+        alias="columnWidths",
+        description=(
+            "Column widths in points; length must be ≤ table column count (over-length triggers 4002 INVALID_PARAM)"
+        ),
+    )
+    alignment: Literal["Left", "Centered", "Right"] | None = Field(
+        default=None,
+        alias="alignment",
+        description="Whole-table horizontal alignment (Word.Alignment enum value)",
+    )
+
+
+class UpdateTableFormatResult(SocketIOBaseModel):
+    """Result for word:update:tableFormat operation.
+
+    OASP v0.2.0 wire shape: {tableId, rowCount, columnCount}.
+    """
+
+    table_id: str = Field(..., alias="tableId", description="Table identifier")
+    row_count: int = Field(
+        ...,
+        alias="rowCount",
+        description="Total row count of the table",
+        ge=0,
+    )
+    column_count: int = Field(
+        ...,
+        alias="columnCount",
+        description="Total column count of the table",
+        ge=0,
+    )
+
+
+class WordUpdateTableFormatResponse(SocketIOBaseModel):
+    """Response for word:update:tableFormat operation."""
+
+    request_id: str = Field(..., alias="requestId", description="Request ID being responded to")
+    success: bool = Field(..., alias="success", description="Whether the operation succeeded")
+    data: UpdateTableFormatResult | None = Field(default=None, alias="data", description="Format result")
+    error: Optional["ErrorResponse"] = Field(default=None, alias="error", description="Error details if failed")
+    timestamp: int = Field(..., alias="timestamp", description="Server timestamp in milliseconds")
+
+
 # Resolve forward references
 GetCommentsOptions.model_rebuild()
 CommentReplyData.model_rebuild()
@@ -1353,3 +1826,22 @@ DocumentStructure.model_rebuild()
 WordGetDocumentStructureResponse.model_rebuild()
 DocumentStats.model_rebuild()
 WordGetDocumentStatsResponse.model_rebuild()
+
+# Table operation DTOs (v0.2.0)
+CellFormat.model_rebuild()
+TableSummary.model_rebuild()
+MergeCellsRequestedRange.model_rebuild()
+MergeCellsResult.model_rebuild()
+WordMergeCellsResponse.model_rebuild()
+TableCellUpdate.model_rebuild()
+UpdateTableCellResult.model_rebuild()
+WordUpdateTableCellResponse.model_rebuild()
+TableRowUpdate.model_rebuild()
+TableColumnUpdate.model_rebuild()
+UpdateTableRowColumnResult.model_rebuild()
+WordUpdateTableRowColumnResponse.model_rebuild()
+TableCellPadding.model_rebuild()
+TableStyleOptions.model_rebuild()
+TableBorderOptions.model_rebuild()
+UpdateTableFormatResult.model_rebuild()
+WordUpdateTableFormatResponse.model_rebuild()

--- a/office4ai/office/mcp/server.py
+++ b/office4ai/office/mcp/server.py
@@ -58,11 +58,15 @@ class OfficeMCPServer(BaseMCPServer):
             WordInsertTableTool,
             WordInsertTextTool,
             WordInsertTOCTool,
+            WordMergeCellsTool,
             WordReplaceSelectionTool,
             WordReplaceTextTool,
             WordReplyCommentTool,
             WordResolveCommentTool,
             WordSelectTextTool,
+            WordUpdateTableCellTool,
+            WordUpdateTableFormatTool,
+            WordUpdateTableRowColumnTool,
         )
 
         word_tools = [
@@ -84,6 +88,11 @@ class OfficeMCPServer(BaseMCPServer):
             WordInsertTableTool(self.workspace),
             WordInsertEquationTool(self.workspace),
             WordInsertTOCTool(self.workspace),
+            # Table operation tools (OASP /word Draft, v0.2.0)
+            WordMergeCellsTool(self.workspace),
+            WordUpdateTableCellTool(self.workspace),
+            WordUpdateTableRowColumnTool(self.workspace),
+            WordUpdateTableFormatTool(self.workspace),
             # Export tool
             WordExportContentTool(self.workspace),
             # Comment tools

--- a/tests/contract_tests/factories/word_factories.py
+++ b/tests/contract_tests/factories/word_factories.py
@@ -563,3 +563,74 @@ class WordDataFactory:
                 "message": message,
             },
         }
+
+    # ------------------------------------------------------------------
+    # Table Operation Responses (OASP /word Draft, v0.2.0)
+    # ------------------------------------------------------------------
+
+    def merge_cells_response(
+        self,
+        table_id: str = "table-0",
+        row_count: int = 1,
+        column_count: int = 5,
+    ) -> dict[str, Any]:
+        """生成 word:merge:cells 响应数据。
+
+        Args:
+            table_id: 目标表格 ID
+            row_count: 合并区域行数
+            column_count: 合并区域列数
+
+        Returns:
+            协议响应数据 {tableId, requestedRange: {rowCount, columnCount}}
+        """
+        return {
+            "tableId": table_id,
+            "requestedRange": {
+                "rowCount": row_count,
+                "columnCount": column_count,
+            },
+        }
+
+    def update_table_cell_response(
+        self,
+        table_id: str = "table-0",
+        cells_updated: int = 1,
+        row_count: int = 5,
+        column_count: int = 4,
+    ) -> dict[str, Any]:
+        """生成 word:update:tableCell 响应数据 (OASP v0.2.0)。"""
+        return {
+            "tableId": table_id,
+            "cellsUpdated": cells_updated,
+            "rowCount": row_count,
+            "columnCount": column_count,
+        }
+
+    def update_table_row_column_response(
+        self,
+        table_id: str = "table-0",
+        cells_updated: int = 0,
+        row_count: int = 5,
+        column_count: int = 4,
+    ) -> dict[str, Any]:
+        """生成 word:update:tableRowColumn 响应数据 (OASP v0.2.0)。"""
+        return {
+            "tableId": table_id,
+            "cellsUpdated": cells_updated,
+            "rowCount": row_count,
+            "columnCount": column_count,
+        }
+
+    def update_table_format_response(
+        self,
+        table_id: str = "table-0",
+        row_count: int = 5,
+        column_count: int = 4,
+    ) -> dict[str, Any]:
+        """生成 word:update:tableFormat 响应数据 (OASP v0.2.0)。"""
+        return {
+            "tableId": table_id,
+            "rowCount": row_count,
+            "columnCount": column_count,
+        }

--- a/tests/contract_tests/word/test_merge_cells.py
+++ b/tests/contract_tests/word/test_merge_cells.py
@@ -1,0 +1,226 @@
+"""
+Contract Tests for word:merge:cells (OASP /word Draft, v0.2.0)
+
+测试 word:merge:cells 事件的请求-响应流程。
+
+OASP Spec: https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from office4ai.environment.workspace.base import OfficeAction
+from office4ai.environment.workspace.office_workspace import OfficeWorkspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_merge_cells_with_explicit_table_id(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """显式 tableId 路径：合并首行 5 列为整行表头单元格。"""
+
+    def response_factory(request: dict) -> dict:
+        # Wire payload uses camelCase per OASP protocol
+        assert "requestId" in request
+        assert "documentUri" in request
+        assert request["tableId"] == "table-0"
+        assert request["startRowIndex"] == 0
+        assert request["startColumnIndex"] == 0
+        assert request["endRowIndex"] == 0
+        assert request["endColumnIndex"] == 4
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.merge_cells_response(table_id="table-0", row_count=1, column_count=5),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:merge:cells", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="merge:cells",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 4,
+            },
+        )
+        result = await workspace.execute(action)
+
+        assert result.success is True, f"Expected success, got error: {result.error}"
+        assert result.data["tableId"] == "table-0"
+        assert result.data["requestedRange"] == {"rowCount": 1, "columnCount": 5}
+
+        assert len(client.received_events) == 1
+        event_name, payload = client.received_events[0]
+        assert event_name == "word:merge:cells"
+        # tableId on the wire — confirms snake_case → camelCase conversion at DTO layer
+        assert payload["tableId"] == "table-0"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_merge_cells_omitted_table_id(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """缺省 tableId 路径：服务端不应在 wire payload 中包含 tableId 键。"""
+
+    def response_factory(request: dict) -> dict:
+        # Optional tableId must be omitted when not provided (exclude_none on DTO)
+        assert "tableId" not in request, "tableId should be omitted when not provided"
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.merge_cells_response(table_id="table-3", row_count=1, column_count=3),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:merge:cells", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="merge:cells",
+            params={
+                "document_uri": client.document_uri,
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 2,
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is True
+        # Add-In resolved tableId from cursor — server propagates the resolved value
+        assert result.data["tableId"] == "table-3"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_merge_cells_no_table_at_cursor(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """缺省 tableId + 光标不在表格内 → 3013 NO_TABLE_AT_CURSOR."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {
+                "code": "3013",
+                "message": "Cursor is not inside a table; specify tableId explicitly.",
+            },
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:merge:cells", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="merge:cells",
+            params={
+                "document_uri": client.document_uri,
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 2,
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "3013" in (result.error or "")
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_merge_cells_already_merged(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """目标区域已存在合并冲突 → 3014 ALREADY_MERGED."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {
+                "code": "3014",
+                "message": "Target range conflicts with an existing merged region.",
+            },
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:merge:cells", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="merge:cells",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 1,
+                "end_column_index": 2,
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "3014" in (result.error or "")
+    finally:
+        await client.disconnect()

--- a/tests/contract_tests/word/test_update_table_cell.py
+++ b/tests/contract_tests/word/test_update_table_cell.py
@@ -1,0 +1,200 @@
+"""
+Contract Tests for word:update:tableCell (OASP /word Draft, v0.2.0)
+
+测试 word:update:tableCell 事件的请求-响应流程。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from office4ai.environment.workspace.base import OfficeAction
+from office4ai.environment.workspace.office_workspace import OfficeWorkspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_cell_with_format(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """正常路径：单元格文本 + 完整 CellFormat（蓝底居中白字加粗表头）。"""
+
+    def response_factory(request: dict) -> dict:
+        assert request["tableId"] == "table-0"
+        assert len(request["cells"]) == 1
+        cell = request["cells"][0]
+        assert cell["rowIndex"] == 0
+        assert cell["columnIndex"] == 0
+        assert cell["text"] == "甲方信息"
+        # CellFormat fields must hit the wire in camelCase
+        fmt = cell["format"]
+        assert fmt["horizontalAlignment"] == "Centered"
+        assert fmt["verticalAlignment"] == "Center"
+        assert fmt["backgroundColor"] == "#1F4E79"
+        assert fmt["fontColor"] == "#FFFFFF"
+        assert fmt["bold"] is True
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_cell_response(
+                table_id="table-0", cells_updated=1, row_count=5, column_count=4
+            ),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableCell", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableCell",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "cells": [
+                    {
+                        "rowIndex": 0,
+                        "columnIndex": 0,
+                        "text": "甲方信息",
+                        "format": {
+                            "horizontalAlignment": "Centered",
+                            "verticalAlignment": "Center",
+                            "backgroundColor": "#1F4E79",
+                            "fontColor": "#FFFFFF",
+                            "bold": True,
+                        },
+                    }
+                ],
+            },
+        )
+        result = await workspace.execute(action)
+
+        assert result.success is True, f"Expected success, got error: {result.error}"
+        assert result.data["tableId"] == "table-0"
+        assert result.data["cellsUpdated"] == 1
+        assert result.data["rowCount"] == 5
+        assert result.data["columnCount"] == 4
+
+        assert len(client.received_events) == 1
+        event_name, _ = client.received_events[0]
+        assert event_name == "word:update:tableCell"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_cell_batch(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """批量更新多个单元格（标签/填写区两列结构）。"""
+
+    def response_factory(request: dict) -> dict:
+        assert len(request["cells"]) == 4
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_cell_response(
+                table_id="table-0", cells_updated=4, row_count=5, column_count=4
+            ),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableCell", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableCell",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "cells": [
+                    {
+                        "rowIndex": 1,
+                        "columnIndex": 0,
+                        "text": "甲方",
+                        "format": {"backgroundColor": "#EEEEEE", "bold": True},
+                    },
+                    {"rowIndex": 1, "columnIndex": 1, "text": "ACME Corp"},
+                    {
+                        "rowIndex": 2,
+                        "columnIndex": 0,
+                        "text": "地址",
+                        "format": {"backgroundColor": "#EEEEEE", "bold": True},
+                    },
+                    {"rowIndex": 2, "columnIndex": 1, "text": "上海市"},
+                ],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is True
+        assert result.data["cellsUpdated"] == 4
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_cell_table_not_found(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """tableId 不存在 → 3010 ELEMENT_NOT_FOUND."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {"code": "3010", "message": "tableId 'table-99' not found"},
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableCell", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableCell",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-99",
+                "cells": [{"rowIndex": 0, "columnIndex": 0, "text": "x"}],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "3010" in (result.error or "")
+    finally:
+        await client.disconnect()

--- a/tests/contract_tests/word/test_update_table_format.py
+++ b/tests/contract_tests/word/test_update_table_format.py
@@ -1,0 +1,234 @@
+"""
+Contract Tests for word:update:tableFormat (OASP /word Draft, v0.2.0)
+
+测试 word:update:tableFormat 事件的请求-响应流程。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from office4ai.environment.workspace.base import OfficeAction
+from office4ai.environment.workspace.office_workspace import OfficeWorkspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_format_full(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """整表样式 + 内边距 + 边框 + 列宽 + 对齐。"""
+
+    def response_factory(request: dict) -> dict:
+        assert request["tableId"] == "table-0"
+        assert request["alignment"] == "Centered"
+        assert request["columnWidths"] == [120, 80, 80, 80]
+        # styleOptions / borderOptions 都用 camelCase
+        assert request["styleOptions"]["styleType"] == "Grid Table 4 - Accent 1"
+        assert request["styleOptions"]["bandedRows"] is True
+        assert request["styleOptions"]["cellPadding"] == {
+            "top": 4,
+            "bottom": 4,
+            "left": 6,
+            "right": 6,
+        }
+        assert request["borderOptions"]["location"] == "inside"
+        assert request["borderOptions"]["style"] == "Single"
+        assert request["borderOptions"]["width"] == 0.5
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_format_response(table_id="table-0", row_count=5, column_count=4),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableFormat", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableFormat",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "style_options": {
+                    "styleType": "Grid Table 4 - Accent 1",
+                    "bandedRows": True,
+                    "cellPadding": {"top": 4, "bottom": 4, "left": 6, "right": 6},
+                },
+                "border_options": {
+                    "location": "inside",
+                    "style": "Single",
+                    "width": 0.5,
+                },
+                "column_widths": [120, 80, 80, 80],
+                "alignment": "Centered",
+            },
+        )
+        result = await workspace.execute(action)
+
+        assert result.success is True, f"Expected success, got error: {result.error}"
+        assert result.data["tableId"] == "table-0"
+        assert result.data["rowCount"] == 5
+        assert result.data["columnCount"] == 4
+
+        assert len(client.received_events) == 1
+        event_name, _ = client.received_events[0]
+        assert event_name == "word:update:tableFormat"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_format_borders_only(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """仅边框：清除外框 (style='None') 验证枚举值。"""
+
+    def response_factory(request: dict) -> dict:
+        # 仅 borderOptions 出现，其它可选键被 exclude_none 过滤
+        assert "styleOptions" not in request
+        assert "columnWidths" not in request
+        assert "alignment" not in request
+        assert request["borderOptions"]["location"] == "outside"
+        assert request["borderOptions"]["style"] == "None"
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_format_response(row_count=5, column_count=4),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableFormat", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableFormat",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "border_options": {"location": "outside", "style": "None"},
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is True
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_format_style_not_found(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """styleType 不存在 → 3011 STYLE_NOT_FOUND."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {
+                "code": "3011",
+                "message": "The style does not exist.",
+            },
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableFormat", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableFormat",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "style_options": {"styleType": "NoSuchStyle"},
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "3011" in (result.error or "")
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_format_column_widths_too_long(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """columnWidths 长度超出列数 → 4002 INVALID_PARAM (Add-In 校验)."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {
+                "code": "4002",
+                "message": "columnWidths length exceeds table column count",
+            },
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableFormat", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableFormat",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "column_widths": [60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "4002" in (result.error or "")
+    finally:
+        await client.disconnect()

--- a/tests/contract_tests/word/test_update_table_row_column.py
+++ b/tests/contract_tests/word/test_update_table_row_column.py
@@ -1,0 +1,173 @@
+"""
+Contract Tests for word:update:tableRowColumn (OASP /word Draft, v0.2.0)
+
+测试 word:update:tableRowColumn 事件的请求-响应流程。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from office4ai.environment.workspace.base import OfficeAction
+from office4ai.environment.workspace.office_workspace import OfficeWorkspace
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_row_column_rows(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """按行批量写入 4 行数据。"""
+
+    def response_factory(request: dict) -> dict:
+        assert request["tableId"] == "table-0"
+        assert len(request["rows"]) == 4
+        # First row content sanity
+        assert request["rows"][0]["rowIndex"] == 1
+        assert request["rows"][0]["values"] == ["甲方", "ACME Corp"]
+        # columns key omitted via exclude_none
+        assert "columns" not in request
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_row_column_response(
+                table_id="table-0", cells_updated=8, row_count=5, column_count=4
+            ),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableRowColumn", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableRowColumn",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "rows": [
+                    {"rowIndex": 1, "values": ["甲方", "ACME Corp"]},
+                    {"rowIndex": 2, "values": ["地址", "上海市"]},
+                    {"rowIndex": 3, "values": ["联系人", "张三"]},
+                    {"rowIndex": 4, "values": ["日期", "2026-04-30"]},
+                ],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is True, f"Expected success, got error: {result.error}"
+        assert result.data["cellsUpdated"] == 8
+        assert result.data["rowCount"] == 5
+        assert result.data["columnCount"] == 4
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_row_column_columns(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+    word_factory,
+):
+    """按列批量写入。"""
+
+    def response_factory(request: dict) -> dict:
+        assert "rows" not in request
+        assert len(request["columns"]) == 1
+        assert request["columns"][0]["columnIndex"] == 0
+        assert request["columns"][0]["values"] == ["甲方", "地址", "联系人"]
+
+        return {
+            "requestId": request["requestId"],
+            "success": True,
+            "data": word_factory.update_table_row_column_response(
+                table_id="table-0", cells_updated=3, row_count=5, column_count=4
+            ),
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableRowColumn", response_factory)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableRowColumn",
+            params={
+                "document_uri": client.document_uri,
+                "table_id": "table-0",
+                "columns": [
+                    {"columnIndex": 0, "values": ["甲方", "地址", "联系人"]},
+                ],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is True
+        assert result.data["cellsUpdated"] == 3
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_update_table_row_column_no_table_at_cursor(
+    workspace: OfficeWorkspace,
+    mock_word_client_factory,
+):
+    """缺省 tableId + 光标不在表格内 → 3013 NO_TABLE_AT_CURSOR."""
+
+    def error_response(request: dict) -> dict:
+        return {
+            "requestId": request["requestId"],
+            "success": False,
+            "error": {
+                "code": "3013",
+                "message": "Cursor is not inside a table; specify tableId explicitly.",
+            },
+            "timestamp": int(asyncio.get_event_loop().time() * 1000),
+        }
+
+    client = mock_word_client_factory(
+        server_url="http://127.0.0.1:3003",
+        namespace="/word",
+        client_id="contract_test_word_client",
+        document_uri="file:///tmp/contract_test.docx",
+    )
+
+    client.register_response("word:update:tableRowColumn", error_response)
+    await client.connect()
+
+    try:
+        action = OfficeAction(
+            category="word",
+            action_name="update:tableRowColumn",
+            params={
+                "document_uri": client.document_uri,
+                "rows": [{"rowIndex": 0, "values": ["x", "y"]}],
+            },
+        )
+        result = await workspace.execute(action)
+        assert result.success is False
+        assert "3013" in (result.error or "")
+    finally:
+        await client.disconnect()

--- a/tests/integration_tests/office4ai/office/mcp/test_mcp_protocol.py
+++ b/tests/integration_tests/office4ai/office/mcp/test_mcp_protocol.py
@@ -54,7 +54,7 @@ class TestMCPProtocol:
 
                 # 获取工具列表 | Get tools list
                 tools_result = await session.list_tools()
-                assert len(tools_result.tools) == 42  # 21 Word + 21 PPT
+                assert len(tools_result.tools) == 46  # 25 Word (21 + 4 OASP v0.2.0 table tools) + 21 PPT
 
                 # 验证工具名称前缀 | Verify tool name prefix
                 tool_names = {t.name for t in tools_result.tools}

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/word/test_word_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/word/test_word_tools.py
@@ -29,11 +29,15 @@ from office4ai.a2c_smcp.tools.word import (
     WordInsertTableTool,
     WordInsertTextTool,
     WordInsertTOCTool,
+    WordMergeCellsTool,
     WordReplaceSelectionTool,
     WordReplaceTextTool,
     WordReplyCommentTool,
     WordResolveCommentTool,
     WordSelectTextTool,
+    WordUpdateTableCellTool,
+    WordUpdateTableFormatTool,
+    WordUpdateTableRowColumnTool,
 )
 from office4ai.environment.workspace.base import OfficeObs
 
@@ -79,6 +83,11 @@ class TestToolMetadata:
         (WordDeleteCommentTool, "word_delete_comment", "word", "delete:comment"),
         (WordReplyCommentTool, "word_reply_comment", "word", "reply:comment"),
         (WordResolveCommentTool, "word_resolve_comment", "word", "resolve:comment"),
+        # Phase 3: 4 table operation tools (OASP /word Draft, v0.2.0)
+        (WordMergeCellsTool, "word_merge_cells", "word", "merge:cells"),
+        (WordUpdateTableCellTool, "word_update_table_cell", "word", "update:tableCell"),
+        (WordUpdateTableRowColumnTool, "word_update_table_row_column", "word", "update:tableRowColumn"),
+        (WordUpdateTableFormatTool, "word_update_table_format", "word", "update:tableFormat"),
     ]
 
     @pytest.mark.parametrize("tool_cls,expected_name,expected_category,expected_event", TOOL_SPECS)
@@ -1067,3 +1076,426 @@ class TestCommentIdIntCoercion:
         action = mock_workspace.execute.call_args[0][0]
         assert action.params["comment_id"] == "42"
         assert isinstance(action.params["comment_id"], str)
+
+
+# ============================================================================
+# Word Table Operation Tools (OASP /word Draft, v0.2.0)
+# Covers: word_merge_cells, word_update_table_cell,
+#         word_update_table_row_column, word_update_table_format
+# ============================================================================
+
+
+class TestWordMergeCellsTool:
+    """word_merge_cells normal path + tableId resolution + error code propagation."""
+
+    @pytest.mark.asyncio
+    async def test_merge_cells_with_explicit_table_id(self, mock_workspace):
+        """显式传 table_id → action.params 透传 tableId 与四个边界索引"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "requestedRange": {"rowCount": 1, "columnCount": 5}},
+        )
+
+        tool = WordMergeCellsTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "table_id": "table-0",
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 4,
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert action.category == "word"
+        assert action.action_name == "merge:cells"
+        assert action.params["table_id"] == "table-0"
+        assert action.params["start_row_index"] == 0
+        assert action.params["end_column_index"] == 4
+        assert result["success"] is True
+        assert result["data"]["requestedRange"] == {"rowCount": 1, "columnCount": 5}
+
+    @pytest.mark.asyncio
+    async def test_merge_cells_omitted_table_id_excluded_from_params(self, mock_workspace):
+        """缺省 table_id 时应通过 exclude_none 从 params 中省略，由 Add-In 解析当前光标表格"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "requestedRange": {"rowCount": 1, "columnCount": 3}},
+        )
+
+        tool = WordMergeCellsTool(mock_workspace)
+        await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 2,
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert "table_id" not in action.params
+
+    @pytest.mark.asyncio
+    async def test_merge_cells_negative_index_rejected(self, mock_workspace):
+        """负数行/列索引应被 Pydantic 拦截 (ge=0)，不会触达 workspace.execute"""
+        tool = WordMergeCellsTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "start_row_index": -1,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 2,
+            }
+        )
+
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "code,scenario",
+        [
+            ("3010", "tableId 在文档中未找到"),
+            ("3013", "缺省 tableId + 光标不在表格内"),
+            ("3014", "目标区域已存在合并冲突"),
+        ],
+    )
+    async def test_merge_cells_propagates_error_codes(self, mock_workspace, code, scenario):
+        """3010 / 3013 / 3014 等错误码应通过 OfficeObs.error 透传到工具返回值"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=False,
+            data={},
+            error=f"{code} {scenario}",
+        )
+
+        tool = WordMergeCellsTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "start_row_index": 0,
+                "start_column_index": 0,
+                "end_row_index": 0,
+                "end_column_index": 2,
+            }
+        )
+
+        assert result["success"] is False
+        assert code in result["error"]
+
+
+class TestWordUpdateTableCellTool:
+    """word_update_table_cell normal path + CellFormat enum validation + missing format/text rejection."""
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_with_format(self, mock_workspace):
+        """正常路径：单元格文本 + 完整 CellFormat（蓝底居中白字加粗表头场景）"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "cellsUpdated": 1, "rowCount": 5, "columnCount": 4},
+        )
+
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "table_id": "table-0",
+                "cells": [
+                    {
+                        "rowIndex": 0,
+                        "columnIndex": 0,
+                        "text": "甲方信息",
+                        "format": {
+                            "horizontalAlignment": "Centered",
+                            "verticalAlignment": "Center",
+                            "backgroundColor": "#1F4E79",
+                            "fontColor": "#FFFFFF",
+                            "bold": True,
+                        },
+                    }
+                ],
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert action.action_name == "update:tableCell"
+        assert action.params["table_id"] == "table-0"
+        cell = action.params["cells"][0]
+        assert cell["row_index"] == 0
+        assert cell["text"] == "甲方信息"
+        # snake_case is expected internally because DTO field names are snake_case
+        assert cell["format"]["horizontal_alignment"] == "Centered"
+        assert cell["format"]["background_color"] == "#1F4E79"
+        assert cell["format"]["bold"] is True
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_rejects_invalid_alignment_value(self, mock_workspace):
+        """horizontalAlignment 必须是 Word.Alignment 枚举值: 'Center' 应被拒绝, 'Centered' 才合法"""
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "cells": [
+                    {
+                        "rowIndex": 0,
+                        "columnIndex": 0,
+                        "format": {"horizontalAlignment": "Center"},  # ✗ 应该是 Centered
+                    }
+                ],
+            }
+        )
+
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_accepts_justified_alignment(self, mock_workspace):
+        """horizontalAlignment='Justified' 是 Word.Alignment 合法值"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "cellsUpdated": 1, "rowCount": 5, "columnCount": 4},
+        )
+
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "cells": [
+                    {
+                        "rowIndex": 1,
+                        "columnIndex": 1,
+                        "text": "long paragraph",
+                        "format": {"horizontalAlignment": "Justified"},
+                    }
+                ],
+            }
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_rejects_invalid_vertical_alignment(self, mock_workspace):
+        """verticalAlignment 必须是 'Top' | 'Center' | 'Bottom'，'Middle' 应被拒绝"""
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "cells": [
+                    {
+                        "rowIndex": 0,
+                        "columnIndex": 0,
+                        "format": {"verticalAlignment": "Middle"},  # ✗ 应该是 Center
+                    }
+                ],
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_empty_cells_rejected(self, mock_workspace):
+        """cells 必须 min_length=1，空数组应被拒绝"""
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "cells": [],
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_cell_propagates_3010(self, mock_workspace):
+        """tableId 不存在 → 3010 ELEMENT_NOT_FOUND 通过 error 透传"""
+        mock_workspace.execute.return_value = OfficeObs(success=False, data={}, error="3010 tableId not found")
+        tool = WordUpdateTableCellTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "table_id": "table-99",
+                "cells": [{"rowIndex": 0, "columnIndex": 0, "text": "x"}],
+            }
+        )
+        assert result["success"] is False
+        assert "3010" in result["error"]
+
+
+class TestWordUpdateTableRowColumnTool:
+    """word_update_table_row_column 正常路径 + rows/columns 必须至少二选一."""
+
+    @pytest.mark.asyncio
+    async def test_update_table_row_column_with_rows(self, mock_workspace):
+        """正常路径：批量按行写入 4 行数据"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "cellsUpdated": 8, "rowCount": 5, "columnCount": 4},
+        )
+
+        tool = WordUpdateTableRowColumnTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "table_id": "table-0",
+                "rows": [
+                    {"rowIndex": 1, "values": ["甲方", "ACME Corp"]},
+                    {"rowIndex": 2, "values": ["地址", "上海市"]},
+                    {"rowIndex": 3, "values": ["联系人", "张三"]},
+                    {"rowIndex": 4, "values": ["日期", "2026-04-30"]},
+                ],
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert action.action_name == "update:tableRowColumn"
+        assert len(action.params["rows"]) == 4
+        assert action.params["rows"][0]["values"] == ["甲方", "ACME Corp"]
+        # columns 缺省时应通过 exclude_none 省略
+        assert "columns" not in action.params
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_table_row_column_with_columns(self, mock_workspace):
+        """正常路径：按列写入"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "cellsUpdated": 3, "rowCount": 5, "columnCount": 4},
+        )
+
+        tool = WordUpdateTableRowColumnTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "columns": [{"columnIndex": 0, "values": ["甲方", "地址", "联系人"]}],
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert "rows" not in action.params
+        assert action.params["columns"][0]["column_index"] == 0
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_table_row_column_requires_rows_or_columns(self, mock_workspace):
+        """rows 和 columns 都缺省应被 model_validator 拦截"""
+        tool = WordUpdateTableRowColumnTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+
+class TestWordUpdateTableFormatTool:
+    """word_update_table_format 正常路径 + Word.Alignment 枚举校验 + 错误码透传."""
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_full(self, mock_workspace):
+        """正常路径：内边距 + 边框 + 列宽 + 整表对齐"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=True,
+            data={"tableId": "table-0", "rowCount": 5, "columnCount": 4},
+        )
+
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "table_id": "table-0",
+                "style_options": {
+                    "cellPadding": {"top": 4, "bottom": 4, "left": 6, "right": 6},
+                },
+                "border_options": {
+                    "location": "inside",
+                    "style": "Single",
+                    "width": 0.5,
+                },
+                "column_widths": [120, 80, 80, 80],
+                "alignment": "Centered",
+            }
+        )
+
+        action = mock_workspace.execute.call_args[0][0]
+        assert action.action_name == "update:tableFormat"
+        assert action.params["alignment"] == "Centered"
+        assert action.params["column_widths"] == [120, 80, 80, 80]
+        assert action.params["border_options"]["location"] == "inside"
+        assert action.params["style_options"]["cell_padding"]["top"] == 4
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_rejects_invalid_alignment(self, mock_workspace):
+        """alignment='Center' 应被拒绝（必须用 'Centered'）"""
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "alignment": "Center",  # ✗
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_rejects_invalid_border_location(self, mock_workspace):
+        """borderOptions.location 必须是 'all' | 'inside' | 'outside'"""
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "border_options": {"location": "diagonal"},
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_rejects_zero_border_width(self, mock_workspace):
+        """borderOptions.width 必须 > 0"""
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "border_options": {"width": 0},
+            }
+        )
+        assert result["success"] is False
+        mock_workspace.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_propagates_3011_style_not_found(self, mock_workspace):
+        """styleType 不存在 → 3011 STYLE_NOT_FOUND 通过 error 透传"""
+        mock_workspace.execute.return_value = OfficeObs(success=False, data={}, error="3011 The style does not exist.")
+
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "style_options": {"styleType": "NoSuchStyle"},
+            }
+        )
+        assert result["success"] is False
+        assert "3011" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_table_format_propagates_4002_invalid_column_widths(self, mock_workspace):
+        """columnWidths 长度超出列数 → 4002 INVALID_PARAM 通过 error 透传 (Add-In 校验)"""
+        mock_workspace.execute.return_value = OfficeObs(
+            success=False, data={}, error="4002 columnWidths length exceeds column count"
+        )
+
+        tool = WordUpdateTableFormatTool(mock_workspace)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///test.docx",
+                "column_widths": [60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60],
+            }
+        )
+        assert result["success"] is False
+        assert "4002" in result["error"]

--- a/tests/unit_tests/office4ai/environment/workspace/dtos/test_word_dtos.py
+++ b/tests/unit_tests/office4ai/environment/workspace/dtos/test_word_dtos.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from office4ai.environment.workspace.dtos.common import request_registry
 from office4ai.environment.workspace.dtos.word import (
     AnyContentElement,
+    CellFormat,
     CommentData,
     CommentReplyData,
     ContentMetadata,
@@ -26,7 +28,14 @@ from office4ai.environment.workspace.dtos.word import (
     SelectTextSearchOptions,
     StyleInfo,
     StylesResult,
+    TableBorderOptions,
+    TableCellPadding,
+    TableCellUpdate,
+    TableColumnUpdate,
     TableInsertOptions,
+    TableRowUpdate,
+    TableStyleOptions,
+    TableSummary,
     TextFormat,
     WordDeleteCommentRequest,
     WordGetCommentsRequest,
@@ -43,12 +52,16 @@ from office4ai.environment.workspace.dtos.word import (
     WordInsertCommentRequest,
     WordInsertTableRequest,
     WordInsertTextRequest,
+    WordMergeCellsRequest,
     WordReplaceSelectionRequest,
     WordReplaceSelectionResponse,
     WordReplyCommentRequest,
     WordResolveCommentRequest,
     WordSelectTextRequest,
     WordSelectTextResponse,
+    WordUpdateTableCellRequest,
+    WordUpdateTableFormatRequest,
+    WordUpdateTableRowColumnRequest,
 )
 
 
@@ -2910,3 +2923,254 @@ class TestTableInsertOptionsInsertLocation:
         payload = request.to_payload()
 
         assert payload["options"]["insertLocation"] == "Replace"
+
+
+# ============================================================================
+# Table Operation DTOs (OASP /word Draft, v0.2.0)
+# ============================================================================
+
+
+class TestCellFormat:
+    """CellFormat 枚举值校验 + 别名往返"""
+
+    def test_centered_horizontal_alignment_accepted(self) -> None:
+        fmt = CellFormat(horizontalAlignment="Centered")
+        assert fmt.horizontal_alignment == "Centered"
+
+    def test_justified_horizontal_alignment_accepted(self) -> None:
+        fmt = CellFormat(horizontalAlignment="Justified")
+        assert fmt.horizontal_alignment == "Justified"
+
+    def test_center_horizontal_alignment_rejected(self) -> None:
+        """horizontalAlignment='Center' 必须被拒绝（应是 'Centered'）"""
+        with pytest.raises(ValidationError):
+            CellFormat(horizontalAlignment="Center")
+
+    def test_center_vertical_alignment_accepted(self) -> None:
+        fmt = CellFormat(verticalAlignment="Center")
+        assert fmt.vertical_alignment == "Center"
+
+    def test_middle_vertical_alignment_rejected(self) -> None:
+        """verticalAlignment='Middle' 必须被拒绝（应是 'Center'）"""
+        with pytest.raises(ValidationError):
+            CellFormat(verticalAlignment="Middle")
+
+    def test_zero_font_size_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CellFormat(fontSize=0)
+
+    def test_alias_round_trip(self) -> None:
+        """snake_case 输入 + camelCase 输出"""
+        fmt = CellFormat(
+            horizontal_alignment="Centered",
+            background_color="#1F4E79",
+            font_color="#FFFFFF",
+            bold=True,
+        )
+        payload = fmt.model_dump(by_alias=True, exclude_none=True)
+        assert payload["horizontalAlignment"] == "Centered"
+        assert payload["backgroundColor"] == "#1F4E79"
+        assert payload["fontColor"] == "#FFFFFF"
+        assert payload["bold"] is True
+
+
+class TestTableSummary:
+    """TableSummary (word:get:documentStructure 配套)"""
+
+    def test_camelcase_input_with_optional_heading(self) -> None:
+        s = TableSummary(
+            tableId="table-0",
+            rowCount=5,
+            columnCount=4,
+            precedingHeading="甲方信息",
+        )
+        assert s.table_id == "table-0"
+        assert s.preceding_heading == "甲方信息"
+        payload = s.model_dump(by_alias=True, exclude_none=True)
+        assert payload["tableId"] == "table-0"
+        assert payload["precedingHeading"] == "甲方信息"
+
+    def test_omitted_heading_excluded_from_wire(self) -> None:
+        s = TableSummary(tableId="table-1", rowCount=2, columnCount=3)
+        payload = s.model_dump(by_alias=True, exclude_none=True)
+        assert "precedingHeading" not in payload
+
+
+class TestWordMergeCellsRequest:
+    """word:merge:cells DTO"""
+
+    def test_event_registered(self) -> None:
+        assert request_registry.contains("word:merge:cells")
+        assert request_registry.get("word:merge:cells") is WordMergeCellsRequest
+
+    def test_build_with_explicit_table_id_serializes_camelcase(self) -> None:
+        req = WordMergeCellsRequest.build(
+            document_uri="file:///t.docx",
+            tableId="table-0",
+            startRowIndex=0,
+            startColumnIndex=0,
+            endRowIndex=0,
+            endColumnIndex=4,
+        )
+        payload = req.to_payload()
+        assert payload["tableId"] == "table-0"
+        assert payload["startRowIndex"] == 0
+        assert payload["endColumnIndex"] == 4
+
+    def test_optional_table_id_omitted_from_wire(self) -> None:
+        req = WordMergeCellsRequest.build(
+            document_uri="file:///t.docx",
+            startRowIndex=1,
+            startColumnIndex=1,
+            endRowIndex=2,
+            endColumnIndex=3,
+        )
+        payload = req.to_payload()
+        assert "tableId" not in payload
+
+    def test_negative_index_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WordMergeCellsRequest.build(
+                document_uri="file:///t.docx",
+                startRowIndex=-1,
+                startColumnIndex=0,
+                endRowIndex=0,
+                endColumnIndex=2,
+            )
+
+
+class TestWordUpdateTableCellRequest:
+    """word:update:tableCell DTO"""
+
+    def test_event_registered(self) -> None:
+        assert request_registry.contains("word:update:tableCell")
+
+    def test_build_with_format_and_alias_round_trip(self) -> None:
+        req = WordUpdateTableCellRequest.build(
+            document_uri="file:///t.docx",
+            tableId="table-0",
+            cells=[
+                {
+                    "rowIndex": 0,
+                    "columnIndex": 0,
+                    "text": "甲方信息",
+                    "format": {
+                        "horizontalAlignment": "Centered",
+                        "verticalAlignment": "Center",
+                        "backgroundColor": "#1F4E79",
+                        "fontColor": "#FFFFFF",
+                        "bold": True,
+                    },
+                }
+            ],
+        )
+        payload = req.to_payload()
+        assert payload["tableId"] == "table-0"
+        cell = payload["cells"][0]
+        assert cell["rowIndex"] == 0
+        assert cell["text"] == "甲方信息"
+        assert cell["format"]["horizontalAlignment"] == "Centered"
+        assert cell["format"]["backgroundColor"] == "#1F4E79"
+
+    def test_empty_cells_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            WordUpdateTableCellRequest.build(
+                document_uri="file:///t.docx",
+                cells=[],
+            )
+
+    def test_table_cell_update_accepts_text_only(self) -> None:
+        upd = TableCellUpdate(rowIndex=1, columnIndex=2, text="hello")
+        assert upd.text == "hello"
+        assert upd.format is None
+
+    def test_table_cell_update_accepts_format_only(self) -> None:
+        upd = TableCellUpdate(
+            rowIndex=1,
+            columnIndex=2,
+            format={"backgroundColor": "#EEEEEE"},
+        )
+        assert upd.text is None
+        assert upd.format is not None
+        assert upd.format.background_color == "#EEEEEE"
+
+
+class TestWordUpdateTableRowColumnRequest:
+    """word:update:tableRowColumn DTO"""
+
+    def test_event_registered(self) -> None:
+        assert request_registry.contains("word:update:tableRowColumn")
+
+    def test_rows_only_round_trip(self) -> None:
+        req = WordUpdateTableRowColumnRequest.build(
+            document_uri="file:///t.docx",
+            rows=[
+                TableRowUpdate(rowIndex=1, values=["甲方", "ACME"]),
+                TableRowUpdate(rowIndex=2, values=["地址", "上海"]),
+            ],
+        )
+        payload = req.to_payload()
+        assert len(payload["rows"]) == 2
+        assert payload["rows"][0]["rowIndex"] == 1
+        assert payload["rows"][0]["values"] == ["甲方", "ACME"]
+        assert "columns" not in payload
+
+    def test_columns_only_round_trip(self) -> None:
+        req = WordUpdateTableRowColumnRequest.build(
+            document_uri="file:///t.docx",
+            columns=[TableColumnUpdate(columnIndex=0, values=["甲方", "地址"])],
+        )
+        payload = req.to_payload()
+        assert payload["columns"][0]["columnIndex"] == 0
+        assert "rows" not in payload
+
+
+class TestWordUpdateTableFormatRequest:
+    """word:update:tableFormat DTO"""
+
+    def test_event_registered(self) -> None:
+        assert request_registry.contains("word:update:tableFormat")
+
+    def test_full_format_round_trip(self) -> None:
+        req = WordUpdateTableFormatRequest.build(
+            document_uri="file:///t.docx",
+            tableId="table-0",
+            styleOptions=TableStyleOptions(
+                styleType="Grid Table 4 - Accent 1",
+                bandedRows=True,
+                cellPadding=TableCellPadding(top=4, bottom=4, left=6, right=6),
+            ),
+            borderOptions=TableBorderOptions(location="inside", style="Single", width=0.5),
+            columnWidths=[120, 80, 80, 80],
+            alignment="Centered",
+        )
+        payload = req.to_payload()
+        assert payload["tableId"] == "table-0"
+        assert payload["alignment"] == "Centered"
+        assert payload["columnWidths"] == [120, 80, 80, 80]
+        assert payload["borderOptions"]["location"] == "inside"
+        assert payload["borderOptions"]["style"] == "Single"
+        assert payload["styleOptions"]["styleType"] == "Grid Table 4 - Accent 1"
+        assert payload["styleOptions"]["bandedRows"] is True
+        assert payload["styleOptions"]["cellPadding"]["top"] == 4
+
+    def test_alignment_center_rejected(self) -> None:
+        """alignment='Center' 必须被拒绝（应是 'Centered'）"""
+        with pytest.raises(ValidationError):
+            WordUpdateTableFormatRequest.build(
+                document_uri="file:///t.docx",
+                alignment="Center",
+            )
+
+    def test_border_location_invalid_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TableBorderOptions(location="diagonal")
+
+    def test_border_width_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TableBorderOptions(width=0)
+
+    def test_border_style_none_accepted(self) -> None:
+        """style='None' 是合法枚举值（用于清除边框）"""
+        b = TableBorderOptions(style="None")
+        assert b.style == "None"

--- a/tests/unit_tests/office4ai/office/mcp/test_server.py
+++ b/tests/unit_tests/office4ai/office/mcp/test_server.py
@@ -38,8 +38,8 @@ class TestOfficeMCPServer:
             config = MCPServerConfig()
             server = OfficeMCPServer(config)
 
-            # 21 Word + 21 PPT = 42 tools
-            assert len(server.tools) == 42
+            # 25 Word (21 + 4 OASP v0.2.0 table tools) + 21 PPT = 46 tools
+            assert len(server.tools) == 46
 
             expected_tools = [
                 # Word Get tools
@@ -60,6 +60,11 @@ class TestOfficeMCPServer:
                 "word_insert_table",
                 "word_insert_equation",
                 "word_insert_toc",
+                # Word Table operation tools (OASP /word Draft, v0.2.0)
+                "word_merge_cells",
+                "word_update_table_cell",
+                "word_update_table_row_column",
+                "word_update_table_format",
                 # Word Export tool
                 "word_export_content",
                 # Word Comment tools

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ wheels = [
 
 [[package]]
 name = "office4ai"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

实装 OASP v0.2.0 协议 4 个 Word 表格事件对应的 MCP Tools，让 AI 可以独立产出"蓝底居中表头 + 灰底加粗标签 + 列宽合理 + 内细外粗边框"这类合同/报告级表格美化效果。

- 新增 4 个 MCP Tools：`word_merge_cells` / `word_update_table_cell` / `word_update_table_row_column` / `word_update_table_format`
- 新增共享 DTO：`CellFormat`（Word.Alignment 枚举严格对齐）+ `TableSummary`
- 错误码扩展：`3013` NO_TABLE_AT_CURSOR / `3014` ALREADY_MERGED / `3999` OFFICE_API_ERROR
- Word 工具数：21 → **25**

## Why

Issue [#8](https://github.com/JIAQIA/office4ai/issues/8) 痛点 1 + 2：

- 痛点 1（合并）：AI 想生成横跨整行的表头时只能输出"首行 N 列内容全空、留一格放标题"的妥协结构
- 痛点 2（样式）：AI 影响表格样式的唯一通道仅限字体级 bold/color/fontSize/italic/underline；**无法**设置单元格背景色、对齐、列宽、表格边框

Add-In 侧 [office-editor4ai PR #27 (#23)](https://github.com/JIAQIA/office-editor4ai/pull/27) 已实装这些能力，本 PR 在 Server 侧暴露 MCP 接口闭环。

## What changed

### `office4ai/`

| 类别 | 文件 | 改动 |
|-----|------|------|
| DTO | `environment/workspace/dtos/word.py` | +492 行：4 组 Request/Response + `CellFormat` / `TableSummary` / `TableStyleOptions` / `TableBorderOptions` / `TableCellPadding` / `TableCellUpdate` / `TableRowUpdate` / `TableColumnUpdate` |
| ErrorCode | `environment/workspace/dtos/common.py` | +3：3013 / 3014 / 3999 |
| Tools | `a2c_smcp/tools/word/{merge_cells,update_table_cell,update_table_row_column,update_table_format}.py` | 4 新工具，沿用声明式 BaseTool 模式 |
| Server | `office/mcp/server.py` + `tools/word/__init__.py` | 注册 4 工具，工具数 42 → 46 |

### `tests/`

| 类别 | 文件 | 改动 |
|-----|------|------|
| 单元 | `unit_tests/.../tools/word/test_word_tools.py` | +432 行：28 个新用例覆盖 metadata、execute flow、Pydantic 守门（`Centered` vs `Center`、`Center` vs `Middle`）、错误码透传 |
| 单元 | `unit_tests/.../dtos/test_word_dtos.py` | +264 行：CellFormat / TableSummary / 4 个 Request DTO 的 alias 往返 + 注册表 |
| 集成 | `integration_tests/.../test_mcp_protocol.py` | tools 计数 42 → 46 |
| 集成 | `unit_tests/.../office/mcp/test_server.py` | 同上 |
| 契约 | `contract_tests/word/test_{merge_cells,update_table_cell,update_table_row_column,update_table_format}.py` | 14 个用例覆盖 happy path + 3010/3013/3014/3011/4002 错误路径 |
| 契约 | `contract_tests/factories/word_factories.py` | +71 行：4 个新 response builder |

### Manual E2E

| 文件 | 用途 |
|-----|------|
| `manual_tests/word/test_helpers.py` (+180) | 5 个新 helper（insert_table / merge_cells / update_table_cell / update_table_row_column / update_table_format） |
| `manual_tests/word/test_word_table_e2e.py` (新增) | 自动驱动 4-tool 流水线 + python-docx OOXML 双重验证 + B.2/B.3 错误码自动触发；B.1 走单独 `--mode b1` |
| `docs/manual_tests/word_table_v0.2.0.md` (新增) | 11 项手工验收清单 + Word.js 平台限制说明 |

## Test plan

- [x] **自动测试**：`uv run poe pre-commit` → ✅ ruff lint clean / mypy clean (95 source files) / **887 passed** in 36s
  - 715 unit + 158 integration + 14 new contract
- [x] **Manual E2E `--mode tables`** (在真实 Word + Add-In 环境)：
  - ✅ 表格数 = 1
  - ✅ 首行已合并 (merge_cells)
  - ✅ 首行单元格背景色 = `#1F4E79` (update_table_cell)
  - ✅ 第 2 行文本 = `['甲方', 'ACME Corp']` (update_table_row_column)
  - ✅ tblGrid 列数 = 4，宽度 (dxa) = `[1524000, 1016000, 1016000, 1016000]` (update_table_format)
- [x] **Manual 视觉验收**：A.1～A.6 通过（蓝底白字加粗居中表头 + 灰底加粗标签列 + 边框 + 列宽 + 整表居中）
- [x] **错误码 B.2 + B.3**（自动）：3010 ELEMENT_NOT_FOUND / 3014 ALREADY_MERGED 透传正确
- [x] **错误码 B.1**（手工）：3013 NO_TABLE_AT_CURSOR 触发正确

## 设计要点（值得 reviewer 关注）

- **Adapter 隔离**：`OfficeAction → BaseRequest.from_event() → DTO → to_payload()` 链路在 `populate_by_name=True` 下吃 snake_case 输入、emit camelCase wire；MCP 工具签名与 wire 解耦，未来协议字段调整只改 DTO
- **Result DTO 字段对齐**：3 个 result DTO 的字段已严格对齐 OASP v0.2.0 wire format（`cellsUpdated` + `rowCount` + `columnCount`），早期草稿的 `updatedCount` / `applied` 已修正
- **Word.js 平台限制**：`columnWidths` 在含合并单元格的表上不可设（Microsoft 平台级硬限制），manual E2E 流水线已重排序（`columnWidths` 在 `merge_cells` 之前）。`update_table_format` 不带 `columnWidths` 时仍可在合并表上工作
- **Draft 标记**：所有 4 个工具的 description 显式含 `(OASP /word Draft)`，避免 LLM 误判为稳定契约

## 跨仓协作

| 仓库 | PR / Issue | 状态 |
|------|-----------|------|
| `A2C-SMCP/oasp-protocol` v0.2.0 | commit `77d5ffb` | ✅ 已发版 (2026-04-30) |
| `JIAQIA/office-editor4ai#23` (Add-In 主线) | [PR #27](https://github.com/JIAQIA/office-editor4ai/pull/27) | ✅ Merged |
| `JIAQIA/office-editor4ai#29` (合并表 updateCell bug) | [PR #31](https://github.com/JIAQIA/office-editor4ai/pull/31) | ✅ Merged |
| `JIAQIA/office-editor4ai#30` (rowColumn schema 偏离 OASP) | [PR #32](https://github.com/JIAQIA/office-editor4ai/pull/32) | ✅ Merged |
| `JIAQIA/office-editor4ai#33` (columnWidths 在合并表上的错误映射) | — | 🆕 跟进 Issue（不阻塞本 PR） |

## 引用

- Closes #8
- 关联 JIRA: [OF4AI-10](https://turingfocus.atlassian.net/browse/OF4AI-10) · [OF4AI-11](https://turingfocus.atlassian.net/browse/OF4AI-11)
- 协议规范：[OASP v0.2.0 events-word](https://doc.turingfocus.cn/oasp/0.2.0/specification/events-word/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)