### PR TITLE
feat(ppt): expose 3 OASP /ppt Draft chart MCP tools (#9)

### DIFF
--- a/docs/manual_tests/ppt_chart_v0.2.0.md
+++ b/docs/manual_tests/ppt_chart_v0.2.0.md
@@ -1,0 +1,108 @@
+# PPT Chart MCP Tools — 手工验收清单 (OASP /ppt Draft, v0.2.0)
+
+> 配套 Issue [#9](https://github.com/JIAQIA/office4ai/issues/9)。
+>
+> **背景**：PowerPoint Office.js 不暴露图表创建/更新 API（[office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)），
+> 因此 OASP `/ppt` 的 3 个 chart 事件由 office4ai Server 端使用 `python-pptx` 直接改写
+> .pptx OOXML — **不下发 Socket.IO 事件给 Add-In**。完成后 MCP 触发 `resource_updated`
+> 通知 `window://office4ai/ppt` 订阅者，AI / 用户需在 PowerPoint 中重新打开文档以查看效果。
+
+---
+
+## 自动场景（已由 `manual_tests/ppt/test_chart_e2e.py` 覆盖）
+
+```bash
+uv run python manual_tests/ppt/test_chart_e2e.py
+```
+
+| 编号 | 场景 | 通过判据 |
+|------|------|----------|
+| A.1 | `ppt_insert_chart` 柱形图 | `success=True`、返回 `elementId=chart-N`、`requiresReload=True` |
+| A.2 | `ppt_get_chart` 回读 | `chartType`/`categories`/`series`/`title` 与插入参数一致 |
+| A.3 | `ppt_update_chart` 仅修改标题（同 variant） | `updatedFields` 含 `title`；回读标题为新值 |
+| A.4 | `ppt_insert_chart` 散点图 | discriminated union 路由到 `ScatterChartData`；返回 `elementId` |
+| A.5 | `ppt_update_chart` 跨 variant（Scatter → Line） | 必须显式提供 `categories`+`series`；返回新 `elementId`（python-pptx 删旧加新） |
+| B.1 | `3015 INVALID_CHART_DATA` — categorical 维度不匹配 | `success=False`、`error` 含 `"3015"`；不触发 `resource_updated` |
+| B.2 | `3015 INVALID_CHART_DATA` — scatter 非有限值 | `success=False`、`error` 含 `"3015"` |
+| B.3 | `3010 ELEMENT_NOT_FOUND` — 不存在的 `chart-N` | `success=False`、`error` 含 `"3010"` |
+| C   | OOXML 双重验证 | `python-pptx` 读取 .pptx 后 `chart_count == 2`、标题含「修订版」 |
+| D   | `notify_resource_updated` 调用记账 | 写操作精确触发 4 次；错误路径不触发；URIs = `[/ppt, /]` |
+
+---
+
+## 视觉验收清单（必须在 PowerPoint 中肉眼检查）
+
+> 自动脚本完成后，工作副本保留在 `manual_tests/.test_working/ppt_chart_v0_2_0/`。
+> 用 PowerPoint 打开最新一份 `charts_demo_*.pptx`，逐项打勾：
+
+- [ ] **A.1 视觉 — 柱形图**：第 1 张幻灯片显示 `ColumnClustered` 图表
+  - 标题为「2026 年度业绩（修订版）」
+  - 4 个分组（Q1/Q2/Q3/Q4），每组两根柱子（营收 / 成本）
+  - 图例可见（默认 `showLegend=True`）；数值标签隐藏（`showDataLabels=False`）
+- [ ] **A.4 视觉 — 散点图初版**（A.5 之前的状态）：在 A.5 跨 variant 切换前，第 2 张曾是散点图（5 个数据点，标题「广告投入 vs 销售额」）。运行脚本后该图已被替换为折线图。
+- [ ] **A.5 视觉 — 跨 variant 切换为折线图**：第 2 张幻灯片显示 `Line` 图表
+  - 4 个 X 轴标签（Jan/Feb/Mar/Apr）
+  - 1 条折线（趋势 10 → 25 → 30 → 28）
+- [ ] **几何位置正确**：两个图表均靠左上对齐（left=60pt, top=60pt），尺寸 540×360pt
+- [ ] **保存兼容**：在 PowerPoint 中保存（`Cmd+S`）后再次打开，所有图表渲染正常（验证 OOXML 写入未破坏 ZIP 包结构）
+- [ ] **AI 业务闭环**：通过 MCP 客户端列出工具，确认 `ppt_insert_chart` / `ppt_get_chart` / `ppt_update_chart` 出现在 `tools/list` 响应中；description 含 `(OASP /ppt Draft)`
+- [ ] **save() 警告生效**：在 Add-In 已连接、文档有未保存改动时调用 `ppt_insert_chart`，确认 LLM 阅读到 description 中的 `Add-In MUST call save()` 提示并优先调用现有的保存路径（手工模拟 — 没有真实保存 → AI 应主动告警或先 save）
+
+---
+
+## 已知限制
+
+1. **Add-In 持有文档时拒绝写入（fail-loud 防御）**：经实验验证，PowerPoint 打开
+   .pptx 后任何 Add-In 触发的 save 都会以内存模型整体覆盖磁盘——Server-OOXML
+   写入的 chart 被静默销毁。本 PR 在 `ppt_insert_chart` / `ppt_update_chart`
+   入口加了硬防御：当 `workspace.get_document_status(uri) == CONNECTED` 时返回
+   `3003 DOCUMENT_READ_ONLY` 并附明确文案，让 LLM 提示用户「先关闭文档」。
+   `ppt_get_chart` 不受影响（只读，最坏情况是返回 stale 数据）。
+2. **Add-In 自动重载未实装**：当前实现仅返回 `requiresReload: true` 标志 +
+   触发 MCP 资源更新通知。Add-In 端的"自动重新打开 .pptx"机制需要新的
+   OASP 事件（如 `ppt:notify:reload`），属下一阶段工作。
+3. **延迟 >1s**：每次 chart 操作都会完整解析 + 序列化整个 .pptx OOXML。中等大小文档（10–20 页 + 嵌入资源）单次操作通常耗时 1–3 秒。LLM 应在 description 引导下避免短时间内大量串行调用。
+4. **并发串行化**：同一 `documentUri` 的并发 chart 调用通过 `DocumentLockManager` 串行化；不同文档的并发调用并行不阻塞。
+5. **`update:chart` 必须提供 `chartType`**：作为 Pydantic `discriminator`。AI 应先 `ppt_get_chart` 读出当前 `chartType` 再回填到 `ppt_update_chart` 的入参。
+6. **跨 variant 切换会刷新 elementId**：`Scatter → Line` 等跨 variant 操作内部走"删旧加新"路径，返回的新 `elementId` 与原 `elementId` 不同；AI 必须采纳响应中的新 ID。
+
+## 冲突实验数据（`--mode conflict`，2026-04-30 实测）
+
+```
+Phase A — Server 写 chart → Add-In 加 image → save
+  [起点]                    s0=0c/0p
+  [A.1 Server chart]        s0=1c/0p     ← 磁盘有 chart
+  [A.2 Add-In image (内存)]  s0=1c/0p     ← PowerPoint 内存独立，磁盘未变
+  [A.3 AFTER save]          s0=0c/1p ❗  ← chart 被静默覆盖
+
+Phase B — Add-In image+save → Server chart → Add-In image → save
+  [B.1 add-in img + save]   s1=0c/1p
+  [B.2 Server chart]        s1=1c/1p     ← image+chart 共存
+  [B.3 add-in img (内存)]    s1=1c/1p     ← 磁盘未变
+  [B.4 AFTER save]          s1=0c/2p ❗  ← chart 再次被静默覆盖
+
+Phase C — 关闭后再插，验证恢复路径
+  [C.0 工具防御]             3003 拒绝   ← Add-In 仍连着，不让插
+  [user closes file]
+  [C.2 Add-In disconnect]   poll 监测到 → 工具放行
+  [C.3 Server chart slide 2] s2=1c/0p   ← 关闭后写盘成功
+  [C.4 AppleScript reopen]
+  [C.6 disk truth]          s2=1c/0p ✅  ← chart 在 PowerPoint reload 后仍在
+```
+
+`c` = chart, `p` = picture. 完整时间线见 `manual_tests/.test_working/` 下脚本输出。
+
+**结论**：PowerPoint for Mac 的设计就是「打开后磁盘是陈旧快照、save 是
+dump 而非 merge」。没有外部文件感知、没有冲突提示、没有 merge。唯一安全的
+Server-OOXML 写入窗口是「Add-In 未持有此文档」——这正是我们在工具入口
+做的检查。
+
+---
+
+## 参考
+
+- 协议：[OASP v0.2.0 events-ppt — `/ppt` Chart 类事件](https://doc.turingfocus.cn/oasp/0.2.0/specification/events-ppt/)
+- 数据结构：[OASP v0.2.0 data-structures — ChartType / ChartData](https://doc.turingfocus.cn/oasp/0.2.0/specification/data-structures/)
+- 错误码：[OASP v0.2.0 error-handling — `3015 INVALID_CHART_DATA`](https://doc.turingfocus.cn/oasp/0.2.0/specification/error-handling/)
+- 实现：`office4ai/environment/workspace/services/chart_engine.py`
+- 工具：`office4ai/a2c_smcp/tools/ppt/{insert,get,update}_chart.py`

--- a/manual_tests/ppt/test_chart_e2e.py
+++ b/manual_tests/ppt/test_chart_e2e.py
@@ -1,0 +1,755 @@
+"""
+PPT Chart End-to-End Test (OASP /ppt Draft, v0.2.0 — Server OOXML)
+
+Issue #9 验收：依次驱动 3 个新 chart MCP 工具并用 python-pptx 双重验证 OOXML 结构。
+Chart 类事件由 OASP Server 端通过 python-pptx 直接修改 .pptx。
+
+两种运行模式：
+
+────────────────────────────────────────────────────────────────────
+  --mode offline (默认)
+────────────────────────────────────────────────────────────────────
+不依赖 Add-In，纯离线跑通三件工具 + 错误码 + OOXML 双重验证。
+主要用作 PR / CI 阶段的回归保护。
+
+    uv run python manual_tests/ppt/test_chart_e2e.py
+    # or
+    uv run python manual_tests/ppt/test_chart_e2e.py --mode offline
+
+覆盖：
+- ✅ ppt_insert_chart   插入分类型图 + 散点图
+- ✅ ppt_get_chart      回读数据
+- ✅ ppt_update_chart   仅改标题（同 variant）+ 跨 variant 切换
+- ✅ 3015 INVALID_CHART_DATA — categorical 维度不匹配 / scatter 非有限值
+- ✅ 3010 ELEMENT_NOT_FOUND — 不存在的 chart-N
+- ✅ requiresReload 标志 + notify_resource_updated 调用次数
+
+────────────────────────────────────────────────────────────────────
+  --mode conflict
+────────────────────────────────────────────────────────────────────
+**真实环境冲突实验**：把 Server-OOXML 路径（chart）与 Add-In Office.js 路径
+（image）交替运行，观察两条写入路径在同一 .pptx 上的实际冲突表现。
+
+需要：
+  - macOS（依赖 AppleScript 强制保存）
+  - PowerPoint 已启动并允许加载项
+  - office-editor4ai Add-In 可用
+
+    uv run python manual_tests/ppt/test_chart_e2e.py --mode conflict
+
+实验目的：验证 README / docs/manual_tests/ppt_chart_v0.2.0.md 中描述的
+「Server OOXML 写入 vs PowerPoint 内存模型」冲突——预期会观察到 chart
+在 Add-In 触发 save() 后被 PowerPoint 内存覆盖的现象，从而为后续
+「ppt:notify:reload」OASP 扩展提供数据依据。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make this script runnable both as `python -m` and as a path
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from pptx import Presentation  # noqa: E402
+
+from office4ai.a2c_smcp.tools.ppt.get_chart import PptGetChartTool  # noqa: E402
+from office4ai.a2c_smcp.tools.ppt.insert_chart import PptInsertChartTool  # noqa: E402
+from office4ai.a2c_smcp.tools.ppt.update_chart import PptUpdateChartTool  # noqa: E402
+
+WORKING_ROOT = _PROJECT_ROOT / "manual_tests" / ".test_working" / "ppt_chart_v0_2_0"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _build_workspace_mock() -> tuple[Any, list[list[str]]]:
+    """Mock the workspace surface the chart tools touch (notify + last activity)."""
+    notified: list[list[str]] = []
+    ws = MagicMock()
+    ws.notify_resource_updated = lambda uris: notified.append(list(uris))
+    ws.update_last_activity = MagicMock()
+    return ws, notified
+
+
+def _create_blank_deck(path: Path) -> None:
+    """Two blank slides; chart tests will populate them."""
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[5])
+    prs.slides.add_slide(prs.slide_layouts[5])
+    prs.save(str(path))
+
+
+def _count_charts(path: Path) -> int:
+    prs = Presentation(str(path))
+    n = 0
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if getattr(shape, "has_chart", False):
+                n += 1
+    return n
+
+
+def _chart_titles(path: Path) -> list[str]:
+    prs = Presentation(str(path))
+    titles: list[str] = []
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if not getattr(shape, "has_chart", False):
+                continue
+            chart = shape.chart
+            if chart.has_title:
+                titles.append(chart.chart_title.text_frame.text)
+            else:
+                titles.append("")
+    return titles
+
+
+# ============================================================================
+# Test scenarios
+# ============================================================================
+
+
+async def scenario_insert_categorical_chart(workspace: Any, deck_uri: str) -> str:
+    """A.1 插入柱形图（带标题、图例）"""
+    print("\n📊 A.1  ppt_insert_chart  柱形图")
+    tool = PptInsertChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "chart": {
+                "chartType": "ColumnClustered",
+                "categories": ["Q1", "Q2", "Q3", "Q4"],
+                "series": [
+                    {"name": "营收", "values": [120, 135, 158, 180]},
+                    {"name": "成本", "values": [80, 90, 102, 115]},
+                ],
+                "title": "2026 年度业绩",
+                "showLegend": True,
+                "showDataLabels": False,
+            },
+            "options": {"slideIndex": 0, "left": 60, "top": 60, "width": 540, "height": 360},
+        }
+    )
+    assert result["success"], f"插入失败: {result}"
+    assert result["data"]["requiresReload"] is True
+    eid = result["data"]["elementId"]
+    print(f"   ✅ elementId={eid} chartType={result['data']['chartType']} series={result['data']['seriesCount']}")
+    return eid
+
+
+async def scenario_get_chart(workspace: Any, deck_uri: str, eid: str) -> None:
+    """A.2 读回柱形图数据"""
+    print("\n🔍 A.2  ppt_get_chart  读回数据")
+    tool = PptGetChartTool(workspace)
+    result = await tool.execute({"document_uri": deck_uri, "elementId": eid})
+    assert result["success"], f"读取失败: {result}"
+    chart = result["data"]["chart"]
+    assert chart["chartType"] == "ColumnClustered"
+    assert chart["categories"] == ["Q1", "Q2", "Q3", "Q4"]
+    assert chart["title"] == "2026 年度业绩"
+    assert len(chart["series"]) == 2
+    print(f"   ✅ chartType={chart['chartType']} categories={chart['categories']} title='{chart['title']}'")
+
+
+async def scenario_update_title(workspace: Any, deck_uri: str, eid: str) -> None:
+    """A.3 仅修改标题（同 variant，部分更新）"""
+    print("\n✏️  A.3  ppt_update_chart  仅修改标题")
+    tool = PptUpdateChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "elementId": eid,
+            "chart": {"chartType": "ColumnClustered", "title": "2026 年度业绩（修订版）"},
+        }
+    )
+    assert result["success"], f"更新失败: {result}"
+    assert "title" in result["data"]["updatedFields"]
+    assert result["data"]["requiresReload"] is True
+    print(f"   ✅ updatedFields={result['data']['updatedFields']}")
+
+
+async def scenario_insert_scatter(workspace: Any, deck_uri: str) -> str:
+    """A.4 插入散点图（不同 variant，验证 discriminated union）"""
+    print("\n📈 A.4  ppt_insert_chart  散点图")
+    tool = PptInsertChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "chart": {
+                "chartType": "Scatter",
+                "series": [
+                    {
+                        "name": "广告 vs 销售",
+                        "points": [
+                            {"x": 1000, "y": 50},
+                            {"x": 1500, "y": 80},
+                            {"x": 3000, "y": 200},
+                            {"x": 5000, "y": 350},
+                            {"x": 8000, "y": 600},
+                        ],
+                    }
+                ],
+                "title": "广告投入 vs 销售额",
+            },
+            "options": {"slideIndex": 1, "left": 60, "top": 60, "width": 540, "height": 360},
+        }
+    )
+    assert result["success"], f"插入散点失败: {result}"
+    eid = result["data"]["elementId"]
+    print(f"   ✅ elementId={eid}")
+    return eid
+
+
+async def scenario_cross_variant(workspace: Any, deck_uri: str, eid: str) -> str:
+    """A.5 跨 variant 切换：散点图 → 折线图（必须补 categories+series）"""
+    print("\n🔄 A.5  ppt_update_chart  跨 variant：Scatter → Line")
+    tool = PptUpdateChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "elementId": eid,
+            "chart": {
+                "chartType": "Line",
+                "categories": ["Jan", "Feb", "Mar", "Apr"],
+                "series": [{"name": "趋势", "values": [10, 25, 30, 28]}],
+            },
+        }
+    )
+    assert result["success"], f"跨 variant 失败: {result}"
+    assert result["data"]["chartType"] == "Line"
+    new_eid = result["data"]["elementId"]
+    print(f"   ✅ 新 elementId={new_eid} updatedFields={result['data']['updatedFields']}")
+    return new_eid
+
+
+async def scenario_3015_categorical_dimension(workspace: Any, deck_uri: str) -> None:
+    """B.1 错误码 3015 INVALID_CHART_DATA — categorical 维度不匹配"""
+    print("\n⚠️  B.1  3015 INVALID_CHART_DATA  categorical 维度不匹配")
+    tool = PptInsertChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "chart": {
+                "chartType": "Pie",
+                "categories": ["A", "B", "C"],
+                "series": [{"name": "x", "values": [1, 2]}],  # 2 != 3
+            },
+        }
+    )
+    assert result["success"] is False, f"应失败但成功: {result}"
+    assert "3015" in result["error"], f"错误码非 3015: {result['error']}"
+    print(f"   ✅ 错误返回: {result['error']}")
+
+
+async def scenario_3015_scatter_non_finite(workspace: Any, deck_uri: str) -> None:
+    """B.2 错误码 3015 INVALID_CHART_DATA — scatter 含 NaN/Infinity"""
+    print("\n⚠️  B.2  3015 INVALID_CHART_DATA  scatter 含非有限值")
+    tool = PptInsertChartTool(workspace)
+    result = await tool.execute(
+        {
+            "document_uri": deck_uri,
+            "chart": {
+                "chartType": "Scatter",
+                "series": [{"name": "x", "points": [{"x": float("inf"), "y": 1}]}],
+            },
+        }
+    )
+    assert result["success"] is False
+    assert "3015" in result["error"]
+    print(f"   ✅ 错误返回: {result['error']}")
+
+
+async def scenario_3010_element_not_found(workspace: Any, deck_uri: str) -> None:
+    """B.3 错误码 3010 ELEMENT_NOT_FOUND — 不存在的 chart-N"""
+    print("\n⚠️  B.3  3010 ELEMENT_NOT_FOUND  不存在的 elementId")
+    tool = PptGetChartTool(workspace)
+    result = await tool.execute({"document_uri": deck_uri, "elementId": "chart-99999"})
+    assert result["success"] is False
+    assert "3010" in result["error"]
+    print(f"   ✅ 错误返回: {result['error']}")
+
+
+# ============================================================================
+# Runner
+# ============================================================================
+
+
+async def offline_main() -> int:
+    print("=" * 70)
+    print("PPT Chart MCP Tools — End-to-End OFFLINE (Server OOXML, OASP /ppt Draft v0.2.0)")
+    print("=" * 70)
+
+    # Prepare working dir
+    WORKING_ROOT.mkdir(parents=True, exist_ok=True)
+    deck_path = WORKING_ROOT / f"charts_demo_{int(time.time())}.pptx"
+    _create_blank_deck(deck_path)
+    deck_uri = deck_path.as_uri()
+    print(f"\n📄 工作副本: {deck_path}")
+
+    workspace, notified = _build_workspace_mock()
+
+    # A. Happy path
+    eid_col = await scenario_insert_categorical_chart(workspace, deck_uri)
+    await scenario_get_chart(workspace, deck_uri, eid_col)
+    await scenario_update_title(workspace, deck_uri, eid_col)
+
+    eid_sc = await scenario_insert_scatter(workspace, deck_uri)
+    await scenario_cross_variant(workspace, deck_uri, eid_sc)
+
+    # B. Error paths (must NOT fire reload notification)
+    notified_before_b = len(notified)
+    await scenario_3015_categorical_dimension(workspace, deck_uri)
+    await scenario_3015_scatter_non_finite(workspace, deck_uri)
+    await scenario_3010_element_not_found(workspace, deck_uri)
+    assert len(notified) == notified_before_b, "错误路径不应触发 notify_resource_updated"
+
+    # OOXML-level structural checks
+    print("\n🧪 C  OOXML 双重验证（python-pptx 直接读取 .pptx）")
+    chart_count = _count_charts(deck_path)
+    assert chart_count == 2, f"预期 2 个图表，实际 {chart_count}"
+    print(f"   ✅ 文档中图表数 = {chart_count}")
+
+    titles = _chart_titles(deck_path)
+    print(f"   ✅ 图表标题列表 = {titles}")
+    assert any("修订版" in t for t in titles), "应找到修订版标题"
+
+    # Notify accounting
+    write_ops = 4  # 1 insert col + 1 update title + 1 insert scatter + 1 cross-variant update
+    print(f"\n🔔 D  notify_resource_updated 被调用次数 = {len(notified)} (预期 {write_ops})")
+    assert len(notified) == write_ops
+    for uris in notified:
+        assert uris == ["window://office4ai/ppt", "window://office4ai"]
+
+    print("\n" + "=" * 70)
+    print(f"✅ 全部自动场景通过。请用 PowerPoint 打开 {deck_path.name} 做视觉验收：")
+    print("   - 第 1 张幻灯片：柱形图（标题『2026 年度业绩（修订版）』，营收/成本两条 series）")
+    print("   - 第 2 张幻灯片：折线图（标题『广告投入 vs 销售额』，由散点图跨 variant 切换而来）")
+    print("=" * 70)
+    return 0
+
+
+# ============================================================================
+# CONFLICT-MODE EXPERIMENT (real PowerPoint + real Add-In)
+# ============================================================================
+# Demonstrates the conflict between two write paths on the same .pptx:
+#   - Server-OOXML path (chart_engine writes the file directly)
+#   - Add-In Office.js path (PowerPoint mutates its in-memory model;
+#     write to disk only happens on save)
+#
+# When PowerPoint flushes its in-memory model to disk, it does NOT merge with
+# external changes — it overwrites them. So a Server-inserted chart can be
+# wiped out by a subsequent Add-In save.
+
+# 1×1 transparent PNG (smallest valid baseline image)
+_MINIMAL_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8BQDwAEgAF/pooBPQAAAABJRU5ErkJggg=="
+
+
+def _observe_disk(deck: Path, label: str) -> dict[str, Any]:
+    """Read the on-disk .pptx, return per-slide chart / picture counts."""
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    prs = Presentation(str(deck))
+    per_slide: list[dict[str, int]] = []
+    total_charts = 0
+    total_pictures = 0
+    for slide in prs.slides:
+        ch = sum(1 for s in slide.shapes if getattr(s, "has_chart", False))
+        pic = sum(1 for s in slide.shapes if s.shape_type == MSO_SHAPE_TYPE.PICTURE)
+        per_slide.append({"charts": ch, "pictures": pic})
+        total_charts += ch
+        total_pictures += pic
+    snapshot = {
+        "label": label,
+        "slides": len(prs.slides),
+        "charts": total_charts,
+        "pictures": total_pictures,
+        "per_slide": per_slide,
+    }
+    print(f"   📋 [{label}] charts={total_charts}, pictures={total_pictures}, per_slide={per_slide}")
+    return snapshot
+
+
+async def conflict_main() -> int:
+    """Run the interleaved chart vs image experiment against a real Add-In."""
+    import platform
+
+    if platform.system() != "Darwin":
+        print("❌ conflict 模式仅支持 macOS（依赖 AppleScript 强制保存 PowerPoint）", file=sys.stderr)
+        return 2
+
+    # Lazy imports — these touch a lot of test infra; keep offline mode lightweight.
+    from manual_tests.ppt.e2e_base import (  # noqa: E402
+        PPTTestRunner,
+        save_ppt_document,
+    )
+    from manual_tests.ppt.test_helpers import ppt_insert_image  # noqa: E402
+
+    print("=" * 70)
+    print("PPT Chart × Image CONFLICT EXPERIMENT")
+    print("(Server-OOXML chart writes vs Add-In Office.js image writes)")
+    print("=" * 70)
+    print()
+    print("⚠️  本实验包含三个阶段：")
+    print("    Phase A/B  — 直接调用 chart_engine 绕过工具防御，复现冲突场景")
+    print("                 （证明「没有防御时，PowerPoint save 会覆盖 Server 写入」）")
+    print("    Phase C    — 走完整工具路径，验证 CONNECTED 防御生效，")
+    print("                 引导用户关闭文档，关闭后工具放行，最后重新打开验证持久化")
+    print()
+
+    # Use the existing PPT fixture infra so an empty deck is opened in PowerPoint
+    # and the office-editor4ai Add-In is auto-activated.
+    runner = PPTTestRunner(
+        fixtures_dir=_PROJECT_ROOT / "manual_tests" / "ppt" / "fixtures" / "ppt_e2e",
+        cleanup_on_success=False,  # keep the deck for post-mortem viewing in PowerPoint
+    )
+
+    snapshots: list[dict[str, Any]] = []
+
+    # Use multi_slide.pptx — it has 5 slides so Phase A (slide 0) and Phase B
+    # (slide 1) operate on independent slides. empty.pptx only has 1 slide so
+    # Phase B's slideIndex=1 would be out-of-range.
+    async with runner.run_with_workspace("multi_slide.pptx") as (workspace, fixture):
+        deck_path: Path = fixture.working_path
+        deck_uri: str = fixture.document_uri
+        print(f"\n📄 工作副本: {deck_path}")
+
+        snapshots.append(_observe_disk(deck_path, "0  起点：空 .pptx"))
+
+        # IMPORTANT: Phase A/B 故意绕过工具层的 CONNECTED 防御，直接调用
+        # chart_engine 来「无视防御」地写盘——这样才能复现没有防御时 PowerPoint
+        # 内存模型覆盖磁盘的冲突场景。Phase C 才走完整的工具路径来验证防御 +
+        # 用户关闭后的恢复流程。
+        from office4ai.environment.workspace.dtos.ppt import (
+            CategoricalChartData,
+            CategoricalSeries,
+            ChartInsertOptions,
+        )
+        from office4ai.environment.workspace.services import chart_engine
+
+        # Tool instance is reused in Phase C (defense path).
+        insert_chart_tool = PptInsertChartTool(workspace)
+
+        # ────────────────────────────────────────────────────────────────
+        # Phase A — Server first, Add-In second (no save in between).
+        # Disk gets the chart from chart_engine (we bypass the tool's
+        # CONNECTED defense on purpose to demonstrate the underlying
+        # conflict). PowerPoint memory diverges when Add-In adds an image;
+        # the save AFTER both reveals what PowerPoint flushes to disk.
+        # ────────────────────────────────────────────────────────────────
+        print("\n" + "─" * 70)
+        print("Phase A — Server inserts chart → Add-In inserts image → save")
+        print("        （Server 路径绕过 CONNECTED 防御，仅用于复现冲突）")
+        print("─" * 70)
+
+        print("\n🅰️  A.1  Server: chart_engine.insert_chart on slide 0（绕过工具防御）")
+        r1 = await chart_engine.insert_chart(
+            deck_uri,
+            CategoricalChartData(
+                chartType="ColumnClustered",
+                categories=["Q1", "Q2", "Q3"],
+                series=[CategoricalSeries(name="Rev", values=[100, 150, 200])],
+                title="PHASE-A-CHART",
+            ),
+            ChartInsertOptions(slideIndex=0, left=60, top=60, width=360, height=240),
+        )
+        print(f"   ✅ Server 写盘成功，elementId={r1['elementId']}")
+        snapshots.append(_observe_disk(deck_path, "A.1 after Server chart write"))
+
+        print("\n🅰️  A.2  Add-In: ppt_insert_image on slide 0 (内存写入，未 save)")
+        ok, data, err = await ppt_insert_image(
+            workspace,
+            deck_uri,
+            {"base64": _MINIMAL_PNG_BASE64},
+            options={"slideIndex": 0, "left": 450, "top": 60, "width": 100, "height": 100},
+        )
+        assert ok, f"Add-In image insert 失败: {err}"
+        print(f"   ✅ Add-In 内存改动成功: {data}")
+        # 此时磁盘还未感知 image — PowerPoint 还没保存。
+        snapshots.append(_observe_disk(deck_path, "A.2 right after Add-In insert (BEFORE save)"))
+
+        print("\n🅰️  A.3  AppleScript 强制 PowerPoint 保存（用户按 Cmd+S 的等价操作）")
+        if not save_ppt_document(deck_path):
+            print("   ⚠️  保存失败，无法继续 Phase A")
+            return 3
+        await asyncio.sleep(1.0)  # let the save finish flushing
+        snap_a3 = _observe_disk(deck_path, "A.3 AFTER save — 关键观察点")
+        snapshots.append(snap_a3)
+
+        # Did the chart survive?
+        a_chart_lost = snap_a3["charts"] == 0
+        a_image_present = snap_a3["pictures"] >= 1
+        print()
+        if a_chart_lost and a_image_present:
+            print("   ❗ 观察：保存后 chart 已被 PowerPoint 内存模型覆盖（消失），仅剩 image。")
+            print("       这正是 OASP /ppt 文档警告的冲突场景。")
+        elif not a_chart_lost and a_image_present:
+            print("   🤔 观察：保存后 chart + image 共存——PowerPoint 可能感知到了外部修改。")
+            print("       值得细看：是 PowerPoint 自动 merge 还是文件锁阻止了我们的 OOXML 写入？")
+        else:
+            print(f"   ⚠️  非预期状态：charts={snap_a3['charts']}, pictures={snap_a3['pictures']}")
+
+        # ────────────────────────────────────────────────────────────────
+        # Phase B — Add-In first (with save), then Server, then Add-In op,
+        # then save. Tests whether the Server-inserted chart can survive a
+        # subsequent Add-In save flow.
+        # ────────────────────────────────────────────────────────────────
+        print("\n" + "─" * 70)
+        print("Phase B — Add-In op → save → Server inserts chart → Add-In op → save")
+        print("        （Server 路径同样绕过 CONNECTED 防御）")
+        print("─" * 70)
+
+        print("\n🅱️  B.1  Add-In: ppt_insert_image on slide 1（内存）+ 立即保存")
+        ok, data, err = await ppt_insert_image(
+            workspace,
+            deck_uri,
+            {"base64": _MINIMAL_PNG_BASE64},
+            options={"slideIndex": 1, "left": 60, "top": 60, "width": 100, "height": 100},
+        )
+        assert ok, f"Add-In image insert 失败: {err}"
+        if not save_ppt_document(deck_path):
+            print("   ⚠️  保存失败")
+            return 3
+        await asyncio.sleep(1.0)
+        snapshots.append(_observe_disk(deck_path, "B.1 after Add-In img + save"))
+
+        print("\n🅱️  B.2  Server: chart_engine.insert_chart on slide 1（绕过工具防御，直接写盘）")
+        r2 = await chart_engine.insert_chart(
+            deck_uri,
+            CategoricalChartData(
+                chartType="Pie",
+                categories=["alpha", "beta", "gamma"],
+                series=[CategoricalSeries(name="share", values=[30, 50, 20])],
+                title="PHASE-B-CHART",
+            ),
+            ChartInsertOptions(slideIndex=1, left=200, top=60, width=360, height=240),
+        )
+        print(f"   ✅ Server 写盘成功，elementId={r2['elementId']}")
+        snap_b2 = _observe_disk(deck_path, "B.2 right after Server chart write")
+        snapshots.append(snap_b2)
+
+        print("\n🅱️  B.3  Add-In: 再插一张 image on slide 1（内存）— 模拟用户继续编辑")
+        ok, data, err = await ppt_insert_image(
+            workspace,
+            deck_uri,
+            {"base64": _MINIMAL_PNG_BASE64},
+            options={"slideIndex": 1, "left": 460, "top": 200, "width": 80, "height": 80},
+        )
+        assert ok, f"Add-In second image insert 失败: {err}"
+        snapshots.append(_observe_disk(deck_path, "B.3 after Add-In img (BEFORE save) — 关键观察点"))
+
+        print("\n🅱️  B.4  AppleScript 强制保存 — 关键时刻")
+        if not save_ppt_document(deck_path):
+            print("   ⚠️  保存失败")
+            return 3
+        await asyncio.sleep(1.0)
+        snap_b4 = _observe_disk(deck_path, "B.4 AFTER save — 关键观察点")
+        snapshots.append(snap_b4)
+
+        # In the worst-case prediction: PowerPoint memory has 2 images on slide 1
+        # but no chart. Save flushes that → chart on slide 1 disappears.
+        b_chart_lost = snap_b4["per_slide"][1]["charts"] == 0 and snap_b2["per_slide"][1]["charts"] == 1
+        b_images_present = snap_b4["per_slide"][1]["pictures"] >= 2
+        print()
+        if b_chart_lost and b_images_present:
+            print("   ❗ 观察：B.2 后存在的 chart 被 B.4 的 save 覆盖丢失。")
+            print("       后续 Add-In 操作 + save 会持续覆盖任何 Server-OOXML 写入。")
+        elif not b_chart_lost:
+            print("   🤔 观察：B.4 后 chart 仍然存在——PowerPoint 可能会感知到外部修改并保留。")
+
+        # ────────────────────────────────────────────────────────────────
+        # Phase C — Defense + recovery.
+        # 1) 工具防御：现在调用 chart 工具应该被 3003 拒绝（因 Add-In 仍持有文档）
+        # 2) 引导用户关闭文档 → poll 直到 Add-In 断开
+        # 3) 文档关闭后，再次调用 chart 工具应该成功
+        # 4) AppleScript 重新打开文档
+        # 5) 用 python-pptx 验证 chart 真的留在磁盘上（PowerPoint 读取的版本）
+        # ────────────────────────────────────────────────────────────────
+        print("\n" + "─" * 70)
+        print("Phase C — 防御 + 恢复路径（关闭后再插，验证 chart 真正持久化）")
+        print("─" * 70)
+
+        # C.0 — 验证防御生效：CONNECTED 状态下 insert_chart 必须返回 3003
+        print("\n🅲  C.0  防御验证：当前 Add-In 仍连着此文档，insert_chart 应被拒")
+        rejected = await insert_chart_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Pie",
+                    "categories": ["a"],
+                    "series": [{"name": "x", "values": [1]}],
+                    "title": "SHOULD-BE-REJECTED",
+                },
+                "options": {"slideIndex": 2},
+            }
+        )
+        if rejected["success"]:
+            print(f"   ⚠️  预期被拒，实际成功了：{rejected}")
+            print("       （检查 office4ai/a2c_smcp/tools/ppt/insert_chart.py 的 CONNECTED 防御）")
+            return 4
+        if "3003" not in rejected["error"]:
+            print(f"   ⚠️  预期 3003 错误码，实际：{rejected['error']}")
+            return 4
+        print(f"   ✅ 工具按预期拒绝：{rejected['error'][:80]}...")
+        snapshots.append(_observe_disk(deck_path, "C.0 after rejected insert (no disk change)"))
+
+        # C.1 — Console 提示用户关闭文档
+        print()
+        print("=" * 70)
+        print("🛑  请在 PowerPoint 中关闭这个文档：")
+        print(f"      文件名：{deck_path.name}")
+        print("      操作：点击文档窗口左上角红色关闭按钮，或菜单 File → Close")
+        print("            （如系统提示是否保存，请选择「不保存」以保留 Phase B 写盘的 chart）")
+        print("=" * 70)
+
+        # C.2 — Poll 等待 Add-In disconnect
+        print("\n   ⏳ 等待 Add-In 断开（Socket.IO 连接消失）...")
+        poll_timeout = 90.0
+        poll_interval = 1.0
+        from office4ai.environment.workspace.base import DocumentStatus
+
+        start = asyncio.get_event_loop().time()
+        disconnected = False
+        while asyncio.get_event_loop().time() - start < poll_timeout:
+            status = workspace.get_document_status(deck_uri)
+            if status == DocumentStatus.DISCONNECTED:
+                disconnected = True
+                elapsed = asyncio.get_event_loop().time() - start
+                print(f"   ✅ Add-In 已断开（耗时 {elapsed:.1f}s）")
+                break
+            await asyncio.sleep(poll_interval)
+        if not disconnected:
+            print(f"   ⚠️  {poll_timeout}s 内未检测到断开，跳过 Phase C 后续步骤")
+            return 5
+
+        # 文档关闭后，给 PowerPoint 一秒让它真正释放文件句柄。
+        await asyncio.sleep(1.0)
+        snapshots.append(_observe_disk(deck_path, "C.2 after Add-In disconnect"))
+
+        # C.3 — 现在 insert_chart 应该成功
+        print("\n🅲  C.3  Server: ppt_insert_chart on slide 2（已断开，应成功）")
+        r3 = await insert_chart_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "ColumnClustered",
+                    "categories": ["X", "Y", "Z"],
+                    "series": [{"name": "delta", "values": [10, 20, 30]}],
+                    "title": "PHASE-C-CHART",
+                },
+                "options": {"slideIndex": 2, "left": 60, "top": 60, "width": 480, "height": 320},
+            }
+        )
+        if not r3["success"]:
+            print(f"   ❌ 关闭后 insert_chart 仍失败：{r3}")
+            return 6
+        new_eid = r3["data"]["elementId"]
+        print(f"   ✅ Server 写盘成功，elementId={new_eid}")
+        snap_c3 = _observe_disk(deck_path, "C.3 after Server chart write (closed state)")
+        snapshots.append(snap_c3)
+        if snap_c3["per_slide"][2]["charts"] != 1:
+            print(f"   ⚠️  slide 2 chart 数预期 1，实际 {snap_c3['per_slide'][2]['charts']}")
+            return 7
+
+        # C.4 — 重新打开文档（在 PowerPoint 里）
+        print("\n🅲  C.4  AppleScript 重新打开文档（PowerPoint 加载磁盘最新版本）")
+        from manual_tests.e2e_base import open_document  # local import to keep offline-mode lightweight
+
+        if not open_document(deck_path):
+            print(f"   ⚠️  自动打开失败，请手动打开：{deck_path}")
+        else:
+            print(f"   ✅ 已请求 PowerPoint 打开 {deck_path.name}")
+        # PowerPoint 打开 + 渲染 chart 通常需要几秒；不等待 Add-In 重连即可验证。
+        await asyncio.sleep(3.0)
+
+        # C.5 — 视觉验收提示
+        print("\n🅲  C.5  请在 PowerPoint 中视觉确认：")
+        print("       第 1 张幻灯片（slide 0）：含一张 image，无 chart（Phase A 残留）")
+        print("       第 2 张幻灯片（slide 1）：含 2 张 image，无 chart（Phase B 残留）")
+        print("       第 3 张幻灯片（slide 2）：✨ 含柱形图 'PHASE-C-CHART'（Phase C 新增）")
+
+        # C.6 — Disk verify (independent of PowerPoint visual)
+        snap_c6 = _observe_disk(deck_path, "C.6 after reopen (disk truth)")
+        snapshots.append(snap_c6)
+        c_chart_persisted = snap_c6["per_slide"][2]["charts"] == 1
+        if c_chart_persisted:
+            print()
+            print("   ✅ Phase C chart 已持久化到磁盘——Server-OOXML 路径在 Add-In 关闭后完全可用。")
+        else:
+            print(f"   ⚠️  Phase C chart 在 reopen 后丢失：{snap_c6['per_slide'][2]}")
+
+    # Done — summarize.
+    print("\n" + "=" * 70)
+    print("📊 实验总结（按时间顺序）")
+    print("=" * 70)
+    for i, snap in enumerate(snapshots):
+        print(
+            f"  [{i}] {snap['label']:50s}  charts={snap['charts']}  "
+            f"pictures={snap['pictures']}  per_slide={snap['per_slide']}"
+        )
+
+    print()
+    print("可在 PowerPoint 中重新打开工作副本以视觉复核：")
+    print(f"   {fixture.working_path}")
+    print()
+    print("根据上面 [A.3] / [B.4] 的关键观察行可以进一步讨论冲突的根因与缓解方案。")
+    return 0
+
+
+def run(mode: str) -> None:
+    try:
+        if mode == "conflict":
+            rc = asyncio.run(conflict_main())
+        else:
+            rc = asyncio.run(offline_main())
+    except AssertionError as e:
+        print(f"\n❌ 断言失败: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n💥 未预期异常: {e}", file=sys.stderr)
+        raise
+    sys.exit(rc)
+
+
+def _parse_args(argv: list[str]) -> tuple[str, bool]:
+    """Tiny arg parser — avoid argparse to keep the script reasonably one-shot."""
+    mode = "offline"
+    clean = False
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--clean":
+            clean = True
+        elif a == "--mode":
+            if i + 1 >= len(argv):
+                print("❌ --mode requires a value (offline|conflict)", file=sys.stderr)
+                sys.exit(2)
+            mode = argv[i + 1]
+            i += 1
+        elif a.startswith("--mode="):
+            mode = a.split("=", 1)[1]
+        elif a in ("-h", "--help"):
+            print(__doc__)
+            sys.exit(0)
+        i += 1
+    if mode not in ("offline", "conflict"):
+        print(f"❌ unknown --mode {mode!r} (expected offline|conflict)", file=sys.stderr)
+        sys.exit(2)
+    return mode, clean
+
+
+if __name__ == "__main__":
+    mode, clean = _parse_args(sys.argv[1:])
+    if clean and WORKING_ROOT.exists():
+        shutil.rmtree(WORKING_ROOT)
+        print(f"🧹 cleaned: {WORKING_ROOT}")
+    run(mode)

--- a/office4ai/a2c_smcp/tools/ppt/__init__.py
+++ b/office4ai/a2c_smcp/tools/ppt/__init__.py
@@ -3,18 +3,21 @@
 from office4ai.a2c_smcp.tools.ppt.add_slide import PptAddSlideTool
 from office4ai.a2c_smcp.tools.ppt.delete_element import PptDeleteElementTool
 from office4ai.a2c_smcp.tools.ppt.delete_slide import PptDeleteSlideTool
+from office4ai.a2c_smcp.tools.ppt.get_chart import PptGetChartTool
 from office4ai.a2c_smcp.tools.ppt.get_current_slide_elements import PptGetCurrentSlideElementsTool
 from office4ai.a2c_smcp.tools.ppt.get_slide_elements import PptGetSlideElementsTool
 from office4ai.a2c_smcp.tools.ppt.get_slide_info import PptGetSlideInfoTool
 from office4ai.a2c_smcp.tools.ppt.get_slide_layouts import PptGetSlideLayoutsTool
 from office4ai.a2c_smcp.tools.ppt.get_slide_screenshot import PptGetSlideScreenshotTool
 from office4ai.a2c_smcp.tools.ppt.goto_slide import PptGotoSlideTool
+from office4ai.a2c_smcp.tools.ppt.insert_chart import PptInsertChartTool
 from office4ai.a2c_smcp.tools.ppt.insert_image import PptInsertImageTool
 from office4ai.a2c_smcp.tools.ppt.insert_shape import PptInsertShapeTool
 from office4ai.a2c_smcp.tools.ppt.insert_table import PptInsertTableTool
 from office4ai.a2c_smcp.tools.ppt.insert_text import PptInsertTextTool
 from office4ai.a2c_smcp.tools.ppt.move_slide import PptMoveSlideTool
 from office4ai.a2c_smcp.tools.ppt.reorder_element import PptReorderElementTool
+from office4ai.a2c_smcp.tools.ppt.update_chart import PptUpdateChartTool
 from office4ai.a2c_smcp.tools.ppt.update_element import PptUpdateElementTool
 from office4ai.a2c_smcp.tools.ppt.update_image import PptUpdateImageTool
 from office4ai.a2c_smcp.tools.ppt.update_table_cell import PptUpdateTableCellTool
@@ -41,6 +44,10 @@ __all__ = [
     "PptUpdateTableRowColumnTool",
     "PptUpdateTableFormatTool",
     "PptUpdateElementTool",
+    # Chart tools (OASP /ppt Draft, v0.2.0 — Server OOXML)
+    "PptInsertChartTool",
+    "PptGetChartTool",
+    "PptUpdateChartTool",
     # Delete & layout tools
     "PptDeleteElementTool",
     "PptReorderElementTool",

--- a/office4ai/a2c_smcp/tools/ppt/get_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/get_chart.py
@@ -1,0 +1,100 @@
+"""ppt_get_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.services import chart_engine
+from office4ai.environment.workspace.services.chart_engine import ChartEngineError
+from office4ai.environment.workspace.services.document_lock import document_lock_manager
+
+
+class PptGetChartInput(BaseModel):
+    """MCP 输入模型：读取已存在图表的当前数据（Server 端 OOXML 离线处理）。"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
+    element_id: str | int = Field(
+        ...,
+        alias="elementId",
+        description=("Chart element ID returned by ppt_insert_chart (format: 'chart-<shape_id>'). Required."),
+    )
+    slide_index: int | None = Field(
+        default=None,
+        alias="slideIndex",
+        description="Optional slide hint to speed up lookup (0-based); elementId remains authoritative.",
+        ge=0,
+    )
+
+    model_config = {"populate_by_name": True}
+
+    # OF4AI-8: LLM may infer numeric IDs as int; coerce to str so engine can parse "chart-N".
+    @field_validator("element_id", mode="before")
+    @classmethod
+    def _coerce_element_id(cls, v: Any) -> Any:
+        return str(v) if isinstance(v, int) else v
+
+
+class PptGetChartTool(BaseTool):
+    """Read an existing chart's data (OASP /ppt Draft, Server OOXML)."""
+
+    @property
+    def name(self) -> str:
+        return "ppt_get_chart"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read an existing PowerPoint chart's logical data and display options "
+            "(OASP /ppt Draft, Server-side OOXML path). "
+            "Returns chartType, categories/points, series, title, showLegend, showDataLabels, "
+            "and geometry (left/top/width/height in points). Inspect chartType FIRST: "
+            "categorical types expose 'categories' + 'series[].values'; Scatter exposes 'series[].points'. "
+            "Recommended call before ppt_update_chart so chartType can be supplied as the discriminator."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return PptGetChartInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "ppt"
+
+    @property
+    def event_name(self) -> str:
+        return "get:chart"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return PptGetChartInput
+
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Override to route through the OOXML chart engine (read-only — still locked to be safe)."""
+        try:
+            validated = self.validate_input(arguments, PptGetChartInput)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+
+        document_uri = validated.document_uri
+        element_id = str(validated.element_id)
+        async with document_lock_manager.acquire(document_uri):
+            try:
+                result_data = await chart_engine.get_chart(
+                    document_uri=document_uri,
+                    element_id=element_id,
+                    slide_index=validated.slide_index,
+                )
+            except ChartEngineError as e:
+                return {"success": False, "error": str(e)}
+            except Exception as e:  # noqa: BLE001
+                return {"success": False, "error": f"3004: {e}"}
+
+        self.workspace.update_last_activity(
+            document_uri=document_uri,
+            tool_name=self.name,
+            result_data=result_data,
+        )
+        return {"success": True, "data": result_data}

--- a/office4ai/a2c_smcp/tools/ppt/insert_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_chart.py
@@ -1,0 +1,121 @@
+"""ppt_insert_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.base import DocumentStatus
+from office4ai.environment.workspace.dtos.ppt import (
+    CategoricalChartData,
+    ChartInsertOptions,
+    ScatterChartData,
+)
+from office4ai.environment.workspace.services import chart_engine
+from office4ai.environment.workspace.services.chart_engine import ChartEngineError
+from office4ai.environment.workspace.services.document_lock import document_lock_manager
+
+# Empirically verified (manual_tests/ppt/test_chart_e2e.py --mode conflict):
+# when the Add-In holds the .pptx open in PowerPoint, the next save() flushes
+# PowerPoint's in-memory model to disk and SILENTLY OVERWRITES any chart this
+# tool just wrote. Until OASP defines a ppt:notify:reload event, refuse the
+# write up-front and surface a clear error so the LLM can prompt the user.
+_CONNECTED_REJECT_MESSAGE = (
+    "3003: Document is currently open in PowerPoint via the Add-In. "
+    "Server-side OOXML chart writes will be silently overwritten by the next "
+    "PowerPoint save (verified empirically — see docs/manual_tests/"
+    "ppt_chart_v0.2.0.md). Please ask the user to close the document in "
+    "PowerPoint, then retry. A future ppt:notify:reload OASP event will lift "
+    "this restriction."
+)
+
+
+class PptInsertChartInput(BaseModel):
+    """MCP 输入模型：在指定 .pptx 中插入图表（Server 端 OOXML 离线处理）。"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
+    chart: CategoricalChartData | ScatterChartData = Field(
+        ...,
+        description=(
+            "Chart payload (discriminated by chartType). "
+            "Categorical (ColumnClustered/Bar/Line/Pie/...): requires categories + series.values. "
+            "Scatter: requires series with points (x, y)."
+        ),
+    )
+    options: ChartInsertOptions | None = Field(
+        default=None,
+        description="Geometry & target slide (optional). Defaults: slideIndex=current, 480x320pt centered.",
+    )
+
+
+class PptInsertChartTool(BaseTool):
+    """Insert a chart on a slide via OOXML rewriting (OASP /ppt Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "ppt_insert_chart"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Insert a chart (column/bar/line/pie/scatter/...) into a PowerPoint slide "
+            "(OASP /ppt Draft, Server-side OOXML path — bypasses Office.js). "
+            "REFUSES with 3003 if the document is currently open in PowerPoint via the Add-In — "
+            "PowerPoint's in-memory model would silently overwrite the chart on the next save. "
+            "When 3003 is returned, ask the user to close the document in PowerPoint, then retry. "
+            "Expect >1s latency. After success the document needs to be reopened to render the new chart "
+            "(an MCP resource_updated notification is fired to /ppt subscribers). "
+            "ChartType discriminates the schema: categorical types (ColumnClustered/ColumnStacked/"
+            "BarClustered/Line/LineMarkers/Pie/Doughnut/Area/Radar) require categories + "
+            "series[].values; Scatter requires series[].points = [{x, y}]. "
+            "Mismatched dimensions trigger 3015 INVALID_CHART_DATA."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return PptInsertChartInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "ppt"
+
+    @property
+    def event_name(self) -> str:
+        return "insert:chart"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return PptInsertChartInput
+
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Override to route through the OOXML chart engine instead of Socket.IO."""
+        try:
+            validated = self.validate_input(arguments, PptInsertChartInput)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+
+        document_uri = validated.document_uri
+        if self.workspace.get_document_status(document_uri) == DocumentStatus.CONNECTED:
+            return {"success": False, "error": _CONNECTED_REJECT_MESSAGE}
+        async with document_lock_manager.acquire(document_uri):
+            try:
+                result_data = await chart_engine.insert_chart(
+                    document_uri=document_uri,
+                    chart_data=validated.chart,
+                    options=validated.options,
+                )
+            except ChartEngineError as e:
+                return {"success": False, "error": str(e)}
+            except Exception as e:  # noqa: BLE001 - surface unexpected I/O errors as 3004
+                return {"success": False, "error": f"3004: {e}"}
+
+        result_data["requiresReload"] = True
+        self.workspace.update_last_activity(
+            document_uri=document_uri,
+            tool_name=self.name,
+            result_data=result_data,
+        )
+        self.workspace.notify_resource_updated(["window://office4ai/ppt", "window://office4ai"])
+        return {"success": True, "data": result_data}

--- a/office4ai/a2c_smcp/tools/ppt/update_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/update_chart.py
@@ -1,0 +1,128 @@
+"""ppt_update_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from office4ai.a2c_smcp.tools.base import BaseTool
+from office4ai.environment.workspace.base import DocumentStatus
+from office4ai.environment.workspace.dtos.ppt import (
+    CategoricalChartUpdate,
+    ScatterChartUpdate,
+)
+from office4ai.environment.workspace.services import chart_engine
+from office4ai.environment.workspace.services.chart_engine import ChartEngineError
+from office4ai.environment.workspace.services.document_lock import document_lock_manager
+
+# Same fail-loud rationale as insert_chart — see that file for the empirical link.
+_CONNECTED_REJECT_MESSAGE = (
+    "3003: Document is currently open in PowerPoint via the Add-In. "
+    "Server-side OOXML chart writes will be silently overwritten by the next "
+    "PowerPoint save (verified empirically — see docs/manual_tests/"
+    "ppt_chart_v0.2.0.md). Please ask the user to close the document in "
+    "PowerPoint, then retry. A future ppt:notify:reload OASP event will lift "
+    "this restriction."
+)
+
+
+class PptUpdateChartInput(BaseModel):
+    """MCP 输入模型：更新已存在图表（Server 端 OOXML 离线处理）。"""
+
+    document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
+    element_id: str | int = Field(
+        ...,
+        alias="elementId",
+        description="Chart element ID (format: 'chart-<shape_id>')",
+    )
+    chart: CategoricalChartUpdate | ScatterChartUpdate = Field(
+        ...,
+        description=(
+            "Update payload (discriminated by chartType — REQUIRED). "
+            "Same-variant change (e.g. Pie → ColumnClustered): categories/series can be omitted "
+            "to keep the originals. Cross-variant change (categorical → Scatter, or vice versa): "
+            "MUST supply new series matching the target shape, otherwise 3015 INVALID_CHART_DATA. "
+            "Tip: call ppt_get_chart first and reuse its chartType to pick the right variant."
+        ),
+    )
+
+    model_config = {"populate_by_name": True}
+
+    @field_validator("element_id", mode="before")
+    @classmethod
+    def _coerce_element_id(cls, v: Any) -> Any:
+        return str(v) if isinstance(v, int) else v
+
+
+class PptUpdateChartTool(BaseTool):
+    """Update an existing chart's data, type, title or display options (OASP /ppt Draft)."""
+
+    @property
+    def name(self) -> str:
+        return "ppt_update_chart"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Update an existing PowerPoint chart in-place via OOXML rewriting "
+            "(OASP /ppt Draft, Server-side path — bypasses Office.js). "
+            "REFUSES with 3003 if the document is currently open in PowerPoint via the Add-In — "
+            "PowerPoint's in-memory model would silently overwrite the update on the next save. "
+            "When 3003 is returned, ask the user to close the document in PowerPoint, then retry. "
+            "Expect >1s latency; concurrent updates on the same document are serialized. "
+            "After success an MCP resource_updated notification is fired; reopen the deck to see the change. "
+            "chartType is the REQUIRED discriminator — call ppt_get_chart first to read it. "
+            "title=null deletes the title; explicit null is preserved on the wire. "
+            "Cross-variant switches (e.g. Pie → Scatter) MUST include compatible series, "
+            "otherwise 3015 INVALID_CHART_DATA. Categorical: series[].values length must match "
+            "categories length."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return PptUpdateChartInput.model_json_schema()
+
+    @property
+    def category(self) -> Literal["word", "ppt", "excel"]:
+        return "ppt"
+
+    @property
+    def event_name(self) -> str:
+        return "update:chart"
+
+    @property
+    def input_model(self) -> type[BaseModel]:
+        return PptUpdateChartInput
+
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Override to route through the OOXML chart engine instead of Socket.IO."""
+        try:
+            validated = self.validate_input(arguments, PptUpdateChartInput)
+        except ValueError as e:
+            return {"success": False, "error": str(e)}
+
+        document_uri = validated.document_uri
+        element_id = str(validated.element_id)
+        if self.workspace.get_document_status(document_uri) == DocumentStatus.CONNECTED:
+            return {"success": False, "error": _CONNECTED_REJECT_MESSAGE}
+        async with document_lock_manager.acquire(document_uri):
+            try:
+                result_data = await chart_engine.update_chart(
+                    document_uri=document_uri,
+                    element_id=element_id,
+                    update=validated.chart,
+                )
+            except ChartEngineError as e:
+                return {"success": False, "error": str(e)}
+            except Exception as e:  # noqa: BLE001
+                return {"success": False, "error": f"3004: {e}"}
+
+        result_data["requiresReload"] = True
+        self.workspace.update_last_activity(
+            document_uri=document_uri,
+            tool_name=self.name,
+            result_data=result_data,
+        )
+        self.workspace.notify_resource_updated(["window://office4ai/ppt", "window://office4ai"])
+        return {"success": True, "data": result_data}

--- a/office4ai/environment/workspace/dtos/common.py
+++ b/office4ai/environment/workspace/dtos/common.py
@@ -378,6 +378,7 @@ class ErrorCode:
     SEARCH_NO_MATCH = "3012"
     NO_TABLE_AT_CURSOR = "3013"
     ALREADY_MERGED = "3014"
+    INVALID_CHART_DATA = "3015"
     OFFICE_API_ERROR = "3999"
 
     # Validation errors (4xxx)

--- a/office4ai/environment/workspace/dtos/ppt.py
+++ b/office4ai/environment/workspace/dtos/ppt.py
@@ -10,11 +10,46 @@ Field naming convention (aligned with Word DTOs):
 - model_dump(by_alias=True): always output camelCase for Socket.IO transmission
 """
 
-from typing import ClassVar, Literal, Optional
+from typing import Annotated, ClassVar, Literal, Optional
 
 from pydantic import Field
 
 from .common import BaseRequest, SocketIOBaseModel
+
+# ============================================================================
+# Chart Type Enumerations (OASP /ppt Draft, v0.2.0)
+# ============================================================================
+# Chart types align with `Excel.ChartType` so callers can cast directly.
+# Two shape variants:
+#   - Categorical (9 types): use `categories` + `series.values`
+#   - Scatter (1 type): use `series.points` (each point is { x, y })
+
+CategoricalChartType = Literal[
+    "ColumnClustered",
+    "ColumnStacked",
+    "BarClustered",
+    "Line",
+    "LineMarkers",
+    "Pie",
+    "Doughnut",
+    "Area",
+    "Radar",
+]
+
+ScatterChartType = Literal["Scatter"]
+
+ChartType = Literal[
+    "ColumnClustered",
+    "ColumnStacked",
+    "BarClustered",
+    "Line",
+    "LineMarkers",
+    "Pie",
+    "Doughnut",
+    "Area",
+    "Radar",
+    "Scatter",
+]
 
 # ============================================================================
 # Content Retrieval DTOs
@@ -496,6 +531,152 @@ class PptGotoSlideRequest(BaseRequest):
     slide_index: int = Field(..., alias="slideIndex", description="Target slide index (0-based)", ge=0)
 
 
+# ============================================================================
+# Chart DTOs (OASP /ppt Draft, v0.2.0)
+# ============================================================================
+# Server-handled OOXML path: these events are intercepted by office4ai Server
+# (python-pptx) and do NOT round-trip through Office.js. See OASP events-ppt
+# admonition for save()/reload constraints.
+
+
+class CategoricalSeries(SocketIOBaseModel):
+    """A single data series in a categorical chart (one value per category)."""
+
+    name: str = Field(..., description="Series name shown in the legend")
+    values: list[float] = Field(
+        ...,
+        description="Numeric Y values; length must equal CategoricalChartData.categories.length",
+    )
+    color: str | None = Field(default=None, description="Optional series color (hex, e.g. '#1F4E79')")
+
+
+class ScatterPoint(SocketIOBaseModel):
+    """One (x, y) sample in a scatter series."""
+
+    x: float = Field(..., description="X coordinate (must be finite)")
+    y: float = Field(..., description="Y coordinate (must be finite)")
+
+
+class ScatterSeries(SocketIOBaseModel):
+    """A single data series in a scatter chart (each point carries its own (x, y))."""
+
+    name: str = Field(..., description="Series name shown in the legend")
+    points: list[ScatterPoint] = Field(..., description="Sample points; length ≥ 1", min_length=1)
+    color: str | None = Field(default=None, description="Optional series color (hex, e.g. '#1F4E79')")
+
+
+class CategoricalChartData(SocketIOBaseModel):
+    """Logical data + display options for categorical charts (column / bar / line / pie / ...)."""
+
+    chart_type: CategoricalChartType = Field(
+        ...,
+        alias="chartType",
+        description="Discriminator selecting the categorical shape",
+    )
+    categories: list[str] = Field(..., description="Discrete X-axis labels (e.g. ['Jan','Feb','Mar'])")
+    series: list[CategoricalSeries] = Field(..., description="Data series (≥ 1)", min_length=1)
+    title: str | None = Field(default=None, description="Optional chart title")
+    show_legend: bool | None = Field(default=None, alias="showLegend", description="Show legend (default true)")
+    show_data_labels: bool | None = Field(
+        default=None, alias="showDataLabels", description="Show data labels (default false)"
+    )
+
+
+class ScatterChartData(SocketIOBaseModel):
+    """Logical data + display options for scatter charts (continuous X, no categories)."""
+
+    chart_type: ScatterChartType = Field(
+        ...,
+        alias="chartType",
+        description="Discriminator literal 'Scatter'",
+    )
+    series: list[ScatterSeries] = Field(..., description="Data series (≥ 1)", min_length=1)
+    title: str | None = Field(default=None, description="Optional chart title")
+    show_legend: bool | None = Field(default=None, alias="showLegend", description="Show legend (default true)")
+    show_data_labels: bool | None = Field(
+        default=None, alias="showDataLabels", description="Show data labels (default false)"
+    )
+
+
+# Discriminated union over chart_type → schema shape.
+# Pydantic / FastMCP idiom: Annotated[Union[...], Field(discriminator=<alias>)].
+# The discriminator uses the wire alias 'chartType' since populate_by_name=True and the
+# nested models declare alias='chartType' on the discriminator field.
+ChartData = Annotated[
+    CategoricalChartData | ScatterChartData,
+    Field(discriminator="chart_type"),
+]
+
+
+class CategoricalChartUpdate(SocketIOBaseModel):
+    """Partial update payload for categorical charts (chartType is required as discriminator)."""
+
+    chart_type: CategoricalChartType = Field(..., alias="chartType", description="Required discriminator")
+    categories: list[str] | None = Field(default=None, description="Replace categories (full overwrite)")
+    series: list[CategoricalSeries] | None = Field(default=None, description="Replace series (full overwrite)")
+    title: str | None = Field(default=None, description="New title; explicit null deletes title")
+    show_legend: bool | None = Field(default=None, alias="showLegend")
+    show_data_labels: bool | None = Field(default=None, alias="showDataLabels")
+
+
+class ScatterChartUpdate(SocketIOBaseModel):
+    """Partial update payload for scatter charts (chartType literal 'Scatter')."""
+
+    chart_type: ScatterChartType = Field(..., alias="chartType", description="Required discriminator")
+    series: list[ScatterSeries] | None = Field(default=None, description="Replace series (full overwrite)")
+    title: str | None = Field(default=None, description="New title; explicit null deletes title")
+    show_legend: bool | None = Field(default=None, alias="showLegend")
+    show_data_labels: bool | None = Field(default=None, alias="showDataLabels")
+
+
+ChartUpdate = Annotated[
+    CategoricalChartUpdate | ScatterChartUpdate,
+    Field(discriminator="chart_type"),
+]
+
+
+class ChartInsertOptions(SocketIOBaseModel):
+    """Geometry + target slide for chart insertion (all optional)."""
+
+    slide_index: int | None = Field(default=None, alias="slideIndex", description="Slide index (default current)", ge=0)
+    left: float | None = Field(default=None, description="X position in points (default centered)")
+    top: float | None = Field(default=None, description="Y position in points (default centered)")
+    width: float | None = Field(default=None, description="Width in points (default 480)", gt=0)
+    height: float | None = Field(default=None, description="Height in points (default 320)", gt=0)
+
+
+class PptInsertChartRequest(BaseRequest):
+    """Request to insert a new chart on a slide (Server-handled OOXML)."""
+
+    event_name: ClassVar[str] = "ppt:insert:chart"
+
+    chart: ChartData = Field(..., description="Chart data (discriminated by chartType)")
+    options: Optional["ChartInsertOptions"] = Field(default=None, description="Geometry + target slide")
+
+
+class PptGetChartRequest(BaseRequest):
+    """Request to read an existing chart's data (Server-handled OOXML)."""
+
+    event_name: ClassVar[str] = "ppt:get:chart"
+
+    element_id: str = Field(..., alias="elementId", description="Chart element ID")
+    slide_index: int | None = Field(
+        default=None,
+        alias="slideIndex",
+        description="Optional slide hint; elementId is authoritative",
+        ge=0,
+    )
+
+
+class PptUpdateChartRequest(BaseRequest):
+    """Request to update an existing chart (Server-handled OOXML)."""
+
+    event_name: ClassVar[str] = "ppt:update:chart"
+
+    element_id: str = Field(..., alias="elementId", description="Chart element ID")
+    chart: ChartUpdate = Field(..., description="Update payload (discriminated by chartType)")
+
+
 # Resolve forward references
 SlideElementsOptions.model_rebuild()
 ScreenshotOptions.model_rebuild()
@@ -515,3 +696,11 @@ RowFormat.model_rebuild()
 ColumnFormat.model_rebuild()
 ElementUpdates.model_rebuild()
 AddSlideOptions.model_rebuild()
+CategoricalSeries.model_rebuild()
+ScatterPoint.model_rebuild()
+ScatterSeries.model_rebuild()
+CategoricalChartData.model_rebuild()
+ScatterChartData.model_rebuild()
+CategoricalChartUpdate.model_rebuild()
+ScatterChartUpdate.model_rebuild()
+ChartInsertOptions.model_rebuild()

--- a/office4ai/environment/workspace/office_workspace.py
+++ b/office4ai/environment/workspace/office_workspace.py
@@ -7,6 +7,7 @@ Office Workspace Implementation
 import asyncio
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -85,6 +86,11 @@ class OfficeWorkspace(BaseWorkspace):
         self._content_cache: dict[str, str] = {}  # document_uri → visible content
         self._structure_cache: dict[str, str] = {}  # document_uri → document structure
 
+        # Server-side OOXML mutations (e.g. chart engine) need to tell MCP
+        # subscribers that the underlying file changed. The owning MCP server
+        # wires this callback at startup; until then it stays None.
+        self._resource_update_callback: Callable[[list[str]], None] | None = None
+
     # ── 活动追踪 API | Activity tracking API ──
 
     def update_last_activity(self, document_uri: str, tool_name: str, result_data: dict[str, Any]) -> None:
@@ -123,6 +129,26 @@ class OfficeWorkspace(BaseWorkspace):
         self._structure_cache.pop(document_uri, None)
         if self._last_activity and self._last_activity.document_uri == document_uri:
             self._last_activity = None
+
+    # ── Resource-update notifications | Resource update notification API ──
+
+    def set_resource_update_callback(self, callback: Callable[[list[str]], None] | None) -> None:
+        """Wire a callback the workspace fires after Server-side OOXML mutations.
+
+        OASP /ppt chart events bypass Office.js and modify .pptx OOXML directly;
+        we use this hook to push MCP ``resource_updated`` notifications so subscribers
+        (window resources for /ppt etc.) know to refetch.
+        """
+        self._resource_update_callback = callback
+
+    def notify_resource_updated(self, uris: list[str]) -> None:
+        """Fire the resource-update callback if one is registered."""
+        if not uris or self._resource_update_callback is None:
+            return
+        try:
+            self._resource_update_callback(uris)
+        except Exception:
+            logger.exception("Resource update callback raised")
 
     async def start(self) -> None:
         """

--- a/office4ai/environment/workspace/services/__init__.py
+++ b/office4ai/environment/workspace/services/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace-level services (e.g. OOXML chart engine, document locks)."""

--- a/office4ai/environment/workspace/services/chart_engine.py
+++ b/office4ai/environment/workspace/services/chart_engine.py
@@ -1,0 +1,746 @@
+"""
+OOXML chart engine for OASP /ppt chart events (insert / get / update).
+
+PowerPoint Office.js does not expose chart creation or data-update APIs (see
+office-js#5463). The OASP protocol therefore routes ppt:insert:chart /
+ppt:get:chart / ppt:update:chart through this Server-side engine, which mutates
+the .pptx OOXML directly via ``python-pptx``.
+
+Operational constraints (mirrored from the OASP events-ppt admonition):
+
+- The Add-In must ``save()`` the document before calling — unsaved client edits
+  will be overwritten when this engine rewrites the .pptx on disk.
+- Concurrent chart calls on the same document must be serialized (see
+  ``document_lock.DocumentLockManager``); two simultaneous writes corrupt the
+  OOXML package.
+- Latency is dominated by disk I/O and python-pptx parsing — typically >1s on
+  multi-MB decks.
+
+Element identity
+================
+We expose ``elementId = "chart-<slide_index>-<shape_id>"`` where ``shape_id``
+is the python-pptx integer (== OOXML ``<p:nvSpPr><p:cNvPr id="...">``). The
+shape id is only unique within a slide, so we prefix the slide index to make
+the wire identifier globally addressable. Backwards-compatible parsing also
+accepts the legacy ``"chart-<shape_id>"`` form (best-effort lookup across all
+slides).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData, XyChartData
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.util import Emu, Pt
+
+from office4ai.environment.workspace.dtos.common import ErrorCode
+from office4ai.environment.workspace.dtos.ppt import (
+    CategoricalChartData,
+    CategoricalChartUpdate,
+    ChartInsertOptions,
+    ScatterChartData,
+    ScatterChartUpdate,
+    ScatterPoint,
+    ScatterSeries,
+)
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ChartEngineError(Exception):
+    """Raised by the engine; carries an OASP error code + human-readable message."""
+
+    code: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial formatting
+        return f"{self.code}: {self.message}"
+
+
+# ---------------------------------------------------------------------------
+# ChartType ↔ XL_CHART_TYPE mapping
+# ---------------------------------------------------------------------------
+
+_CHART_TYPE_MAP: dict[str, XL_CHART_TYPE] = {
+    "ColumnClustered": XL_CHART_TYPE.COLUMN_CLUSTERED,
+    "ColumnStacked": XL_CHART_TYPE.COLUMN_STACKED,
+    "BarClustered": XL_CHART_TYPE.BAR_CLUSTERED,
+    "Line": XL_CHART_TYPE.LINE,
+    "LineMarkers": XL_CHART_TYPE.LINE_MARKERS,
+    "Pie": XL_CHART_TYPE.PIE,
+    "Doughnut": XL_CHART_TYPE.DOUGHNUT,
+    "Area": XL_CHART_TYPE.AREA,
+    "Radar": XL_CHART_TYPE.RADAR,
+    "Scatter": XL_CHART_TYPE.XY_SCATTER,
+}
+
+_CATEGORICAL_TYPES = {
+    "ColumnClustered",
+    "ColumnStacked",
+    "BarClustered",
+    "Line",
+    "LineMarkers",
+    "Pie",
+    "Doughnut",
+    "Area",
+    "Radar",
+}
+
+
+def _xl_chart_type(chart_type: str) -> XL_CHART_TYPE:
+    try:
+        return _CHART_TYPE_MAP[chart_type]
+    except KeyError as exc:
+        raise ChartEngineError(
+            code=ErrorCode.INVALID_PARAM,
+            message=f"Unsupported chartType: {chart_type!r}",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# URI ↔ filesystem path
+# ---------------------------------------------------------------------------
+
+
+def _uri_to_path(document_uri: str) -> Path:
+    """Convert a ``file://`` URI to a local Path. Raises 3001 if invalid."""
+    parsed = urllib.parse.urlparse(document_uri)
+    if parsed.scheme != "file":
+        raise ChartEngineError(
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message=f"Only file:// URIs are supported, got: {document_uri!r}",
+        )
+    # urllib gives us an unquoted path with a leading slash even on macOS/Linux.
+    raw = urllib.parse.unquote(parsed.path)
+    path = Path(raw)
+    if not path.exists():
+        raise ChartEngineError(
+            code=ErrorCode.DOCUMENT_NOT_FOUND,
+            message=f"Document not found: {path}",
+        )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Validation (raises 3015 INVALID_CHART_DATA on dimension issues)
+# ---------------------------------------------------------------------------
+
+
+def _validate_categorical(data: CategoricalChartData) -> None:
+    expected = len(data.categories)
+    for idx, series in enumerate(data.series):
+        if len(series.values) != expected:
+            raise ChartEngineError(
+                code=ErrorCode.INVALID_CHART_DATA,
+                message=(
+                    f"series[{idx}].values length ({len(series.values)}) does not match categories length ({expected})"
+                ),
+            )
+
+
+def _validate_scatter(data: ScatterChartData) -> None:
+    for idx, series in enumerate(data.series):
+        if not series.points:
+            raise ChartEngineError(
+                code=ErrorCode.INVALID_CHART_DATA,
+                message=f"series[{idx}].points must not be empty",
+            )
+        for pidx, p in enumerate(series.points):
+            if not (math.isfinite(p.x) and math.isfinite(p.y)):
+                raise ChartEngineError(
+                    code=ErrorCode.INVALID_CHART_DATA,
+                    message=f"series[{idx}].points[{pidx}] contains non-finite x/y",
+                )
+
+
+# ---------------------------------------------------------------------------
+# python-pptx helpers — chart construction / extraction / mutation
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WIDTH_PT = 480.0
+_DEFAULT_HEIGHT_PT = 320.0
+
+
+def _resolve_geometry(prs: Any, options: ChartInsertOptions | None) -> tuple[Any, Any, Any, Any]:
+    """Resolve (x, y, cx, cy) as python-pptx ``Length`` values. Default 480x320 pt, centered."""
+    width_pt = options.width if options and options.width else _DEFAULT_WIDTH_PT
+    height_pt = options.height if options and options.height else _DEFAULT_HEIGHT_PT
+    cx = Pt(width_pt)
+    cy = Pt(height_pt)
+
+    if options and options.left is not None:
+        x: Any = Pt(options.left)
+    else:
+        x = Emu(max(0, (int(prs.slide_width) - int(cx)) // 2))
+    if options and options.top is not None:
+        y: Any = Pt(options.top)
+    else:
+        y = Emu(max(0, (int(prs.slide_height) - int(cy)) // 2))
+    return x, y, cx, cy
+
+
+def _build_categorical_data(data: CategoricalChartData) -> CategoryChartData:
+    cd = CategoryChartData()  # type: ignore[no-untyped-call]
+    cd.categories = list(data.categories)
+    for series in data.series:
+        cd.add_series(series.name, list(series.values))  # type: ignore[no-untyped-call]
+    return cd
+
+
+def _build_xy_data(data: ScatterChartData) -> XyChartData:
+    cd = XyChartData()  # type: ignore[no-untyped-call]
+    for series in data.series:
+        s = cd.add_series(series.name)  # type: ignore[no-untyped-call]
+        for p in series.points:
+            s.add_data_point(p.x, p.y)
+    return cd
+
+
+def _apply_display_options(
+    chart: Any,
+    title: str | None,
+    show_legend: bool | None,
+    show_data_labels: bool | None,
+    *,
+    title_explicit_none: bool = False,
+) -> None:
+    """Apply title / legend / data-label toggles. ``title_explicit_none`` deletes the title."""
+    if title is not None:
+        chart.has_title = True
+        chart.chart_title.text_frame.text = title
+    elif title_explicit_none:
+        chart.has_title = False
+
+    if show_legend is not None:
+        chart.has_legend = bool(show_legend)
+
+    if show_data_labels is not None and chart.plots:
+        try:
+            chart.plots[0].has_data_labels = bool(show_data_labels)
+        except (AttributeError, ValueError):
+            # Scatter plots don't support data labels via this code path — silently skip.
+            pass
+
+
+def _slide_index(prs: Any, slide: Any) -> int:
+    for idx, s in enumerate(prs.slides):
+        if s is slide:
+            return idx
+    return -1
+
+
+def _parse_element_id(element_id: str) -> tuple[int | None, int]:
+    """Parse ``chart-<slide>-<shape>`` (preferred) or legacy ``chart-<shape>``.
+
+    Returns ``(slide_index_or_None, shape_id)``. Raises 3010 on malformed input.
+    """
+    if not element_id.startswith("chart-"):
+        raise ChartEngineError(
+            code=ErrorCode.ELEMENT_NOT_FOUND,
+            message=f"Invalid chart elementId format: {element_id!r}",
+        )
+    rest = element_id[len("chart-") :]
+    parts = rest.split("-")
+    try:
+        if len(parts) == 2:
+            return int(parts[0]), int(parts[1])
+        if len(parts) == 1:
+            return None, int(parts[0])
+    except ValueError:
+        pass
+    raise ChartEngineError(
+        code=ErrorCode.ELEMENT_NOT_FOUND,
+        message=f"Invalid chart elementId: {element_id!r}",
+    )
+
+
+def _format_element_id(slide_index: int, shape_id: int) -> str:
+    return f"chart-{slide_index}-{shape_id}"
+
+
+def _find_chart(prs: Any, element_id: str, hint_index: int | None = None) -> tuple[Any, Any, int]:
+    """Return (slide, chart_shape, slide_index) for the chart with this elementId.
+
+    Raises 3010 ELEMENT_NOT_FOUND if no chart shape matches.
+    """
+    parsed_slide, shape_id = _parse_element_id(element_id)
+    slides = list(prs.slides)
+    target_slide = parsed_slide if parsed_slide is not None else hint_index
+
+    # Search the qualified slide first, then fall back to the rest.
+    if target_slide is not None and 0 <= target_slide < len(slides):
+        slides_iter = [slides[target_slide]] + [s for i, s in enumerate(slides) if i != target_slide]
+    else:
+        slides_iter = slides
+
+    for slide in slides_iter:
+        for shape in slide.shapes:
+            if not getattr(shape, "has_chart", False):
+                continue
+            if int(shape.shape_id) == shape_id:
+                return slide, shape, _slide_index(prs, slide)
+
+    raise ChartEngineError(
+        code=ErrorCode.ELEMENT_NOT_FOUND,
+        message=f"Chart not found: {element_id}",
+    )
+
+
+_C_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+
+
+def _extract_scatter_points(series: Any) -> list[dict[str, float]]:
+    """Read XY series points by parsing c:xVal / c:yVal numeric refs from OOXML."""
+
+    def _read_axis(parent_tag: str) -> list[float]:
+        node = series._element.find(f"{{{_C_NS}}}{parent_tag}")
+        if node is None:
+            return []
+        num_ref = node.find(f"{{{_C_NS}}}numRef")
+        num_lit = node.find(f"{{{_C_NS}}}numLit")
+        cache = num_ref.find(f"{{{_C_NS}}}numCache") if num_ref is not None else None
+        source = cache if cache is not None else num_lit
+        if source is None:
+            return []
+        out: list[float] = []
+        for pt in source.findall(f"{{{_C_NS}}}pt"):
+            v = pt.find(f"{{{_C_NS}}}v")
+            if v is None or v.text is None:
+                continue
+            try:
+                out.append(float(v.text))
+            except ValueError:
+                continue
+        return out
+
+    xs = _read_axis("xVal")
+    ys = _read_axis("yVal")
+    return [{"x": x, "y": y} for x, y in zip(xs, ys, strict=False)]
+
+
+def _extract_chart_data(chart: Any) -> dict[str, Any]:
+    """Read python-pptx chart back into the OASP ChartData wire shape (camelCase)."""
+    xl_type = chart.chart_type
+    # Reverse-map XL_CHART_TYPE → OASP chartType string.
+    reverse = {v: k for k, v in _CHART_TYPE_MAP.items()}
+    chart_type_str = reverse.get(xl_type)
+    if chart_type_str is None:
+        # Unknown / unmapped concrete enum (e.g. variant subtype) — fall back to closest base.
+        # We pick the first key whose XL_CHART_TYPE shares the same name root.
+        for key, val in _CHART_TYPE_MAP.items():
+            if val == xl_type:
+                chart_type_str = key
+                break
+        chart_type_str = chart_type_str or "ColumnClustered"
+
+    title = None
+    if chart.has_title:
+        title = chart.chart_title.text_frame.text or None
+    show_legend = bool(chart.has_legend)
+    # Scatter plots (CT_ScatterChart) don't expose dLbls — fall back to False.
+    show_data_labels = False
+    if chart.plots:
+        try:
+            show_data_labels = bool(chart.plots[0].has_data_labels)
+        except (AttributeError, ValueError):
+            show_data_labels = False
+
+    if chart_type_str == "Scatter":
+        series_out: list[dict[str, Any]] = []
+        for series in chart.series:
+            points = _extract_scatter_points(series)
+            series_out.append({"name": series.name, "points": points})
+        return {
+            "chartType": "Scatter",
+            "series": series_out,
+            "title": title,
+            "showLegend": show_legend,
+            "showDataLabels": show_data_labels,
+        }
+
+    # Categorical
+    plot = chart.plots[0] if chart.plots else None
+    categories_raw = list(plot.categories) if plot is not None else []
+    categories = [str(c) for c in categories_raw]
+    series_out_cat: list[dict[str, Any]] = []
+    for series in chart.series:
+        values = [float(v) if v is not None else 0.0 for v in series.values]
+        series_out_cat.append({"name": series.name, "values": values})
+    return {
+        "chartType": chart_type_str,
+        "categories": categories,
+        "series": series_out_cat,
+        "title": title,
+        "showLegend": show_legend,
+        "showDataLabels": show_data_labels,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public engine functions
+# ---------------------------------------------------------------------------
+
+
+def _insert_chart_blocking(
+    document_path: Path,
+    chart_data: CategoricalChartData | ScatterChartData,
+    options: ChartInsertOptions | None,
+) -> dict[str, Any]:
+    prs = Presentation(str(document_path))
+
+    slide_index_target = options.slide_index if options and options.slide_index is not None else None
+    if slide_index_target is None:
+        slide_index_target = 0
+    if slide_index_target < 0 or slide_index_target >= len(prs.slides):
+        raise ChartEngineError(
+            code=ErrorCode.INVALID_PARAM,
+            message=(f"slideIndex {slide_index_target} out of range [0, {len(prs.slides) - 1}]"),
+        )
+    slide = prs.slides[slide_index_target]
+
+    x, y, cx, cy = _resolve_geometry(prs, options)
+
+    if isinstance(chart_data, CategoricalChartData):
+        _validate_categorical(chart_data)
+        xl_type = _xl_chart_type(chart_data.chart_type)
+        cd: Any = _build_categorical_data(chart_data)
+    else:
+        _validate_scatter(chart_data)
+        xl_type = _xl_chart_type(chart_data.chart_type)
+        cd = _build_xy_data(chart_data)
+
+    chart_shape: Any = slide.shapes.add_chart(xl_type, x, y, cx, cy, cd)
+    chart = chart_shape.chart
+
+    _apply_display_options(
+        chart,
+        title=chart_data.title,
+        show_legend=chart_data.show_legend,
+        show_data_labels=chart_data.show_data_labels,
+    )
+
+    prs.save(str(document_path))
+
+    element_id = _format_element_id(slide_index_target, int(chart_shape.shape_id))
+    return {
+        "elementId": element_id,
+        "slideIndex": slide_index_target,
+        "chartType": chart_data.chart_type,
+        "seriesCount": len(chart_data.series),
+        "left": Emu(int(chart_shape.left or 0)).pt,
+        "top": Emu(int(chart_shape.top or 0)).pt,
+        "width": Emu(int(chart_shape.width or 0)).pt,
+        "height": Emu(int(chart_shape.height or 0)).pt,
+    }
+
+
+def _get_chart_blocking(document_path: Path, element_id: str, hint_index: int | None) -> dict[str, Any]:
+    prs = Presentation(str(document_path))
+    _slide, shape, slide_idx = _find_chart(prs, element_id, hint_index)
+    chart = shape.chart
+    return {
+        "elementId": element_id,
+        "slideIndex": slide_idx,
+        "chart": _extract_chart_data(chart),
+        "left": Emu(int(shape.left or 0)).pt,
+        "top": Emu(int(shape.top or 0)).pt,
+        "width": Emu(int(shape.width or 0)).pt,
+        "height": Emu(int(shape.height or 0)).pt,
+    }
+
+
+def _is_categorical(chart_type: str) -> bool:
+    return chart_type in _CATEGORICAL_TYPES
+
+
+def _update_chart_blocking(
+    document_path: Path,
+    element_id: str,
+    update: CategoricalChartUpdate | ScatterChartUpdate,
+) -> dict[str, Any]:
+    prs = Presentation(str(document_path))
+    slide, shape, slide_idx = _find_chart(prs, element_id, None)
+    chart = shape.chart
+
+    # Determine current chartType string (best-effort) for variant comparison.
+    reverse = {v: k for k, v in _CHART_TYPE_MAP.items()}
+    current_type = reverse.get(chart.chart_type) or "ColumnClustered"
+
+    target_type = update.chart_type
+    target_is_categorical = _is_categorical(target_type)
+    current_is_categorical = _is_categorical(current_type)
+
+    updated_fields: list[str] = []
+
+    cross_variant = target_is_categorical != current_is_categorical
+    same_variant_type_change = (target_type != current_type) and not cross_variant
+
+    if cross_variant:
+        # Cross-variant switch needs full new series. Rebuild from scratch at the same geometry.
+        if isinstance(update, CategoricalChartUpdate):
+            if update.series is None or update.categories is None:
+                raise ChartEngineError(
+                    code=ErrorCode.INVALID_CHART_DATA,
+                    message=(
+                        "Cross-variant switch to categorical requires both 'categories' and 'series' "
+                        "(scatter shape has no compatible data)"
+                    ),
+                )
+            new_data = CategoricalChartData(
+                chartType=update.chart_type,
+                categories=update.categories,
+                series=update.series,
+                title=update.title,
+                showLegend=update.show_legend,
+                showDataLabels=update.show_data_labels,
+            )
+            _validate_categorical(new_data)
+            cd: Any = _build_categorical_data(new_data)
+        else:
+            if update.series is None:
+                raise ChartEngineError(
+                    code=ErrorCode.INVALID_CHART_DATA,
+                    message="Cross-variant switch to scatter requires 'series' with points",
+                )
+            new_scatter = ScatterChartData(
+                chartType=update.chart_type,
+                series=update.series,
+                title=update.title,
+                showLegend=update.show_legend,
+                showDataLabels=update.show_data_labels,
+            )
+            _validate_scatter(new_scatter)
+            cd = _build_xy_data(new_scatter)
+
+        # Capture geometry, drop old shape, add new chart at same coords.
+        x: Any = Emu(int(shape.left or 0))
+        y: Any = Emu(int(shape.top or 0))
+        cx: Any = Emu(int(shape.width or 0))
+        cy: Any = Emu(int(shape.height or 0))
+        sp = shape._element
+        sp.getparent().remove(sp)
+        new_xl = _xl_chart_type(target_type)
+        new_shape = slide.shapes.add_chart(new_xl, x, y, cx, cy, cd)
+        chart = new_shape.chart
+        element_id = _format_element_id(slide_idx, int(new_shape.shape_id))
+        updated_fields.extend(["chartType", "series"])
+        if isinstance(update, CategoricalChartUpdate) and update.categories is not None:
+            updated_fields.append("categories")
+        _apply_display_options(
+            chart,
+            title=update.title,
+            show_legend=update.show_legend,
+            show_data_labels=update.show_data_labels,
+            title_explicit_none=False,
+        )
+        if update.title is not None:
+            updated_fields.append("title")
+        if update.show_legend is not None:
+            updated_fields.append("showLegend")
+        if update.show_data_labels is not None:
+            updated_fields.append("showDataLabels")
+    else:
+        # Same-variant.
+        # python-pptx does not expose ``chart.chart_type`` as a setter, so a chart-type
+        # change inside the same variant (e.g. Pie → ColumnClustered) is also handled by
+        # delete-and-recreate at the same geometry — same strategy as cross-variant.
+        if same_variant_type_change:
+            current_data = _extract_chart_data(chart)
+            if isinstance(update, CategoricalChartUpdate):
+                new_categories = (
+                    update.categories if update.categories is not None else current_data.get("categories", [])
+                )
+                if update.series is not None:
+                    new_data_full = CategoricalChartData(
+                        chartType=update.chart_type,
+                        categories=list(new_categories),
+                        series=update.series,
+                        title=update.title,
+                        showLegend=update.show_legend,
+                        showDataLabels=update.show_data_labels,
+                    )
+                else:
+                    existing_series_raw = current_data.get("series", [])
+                    existing_series = [
+                        {"name": s.get("name", ""), "values": s.get("values", [])} for s in existing_series_raw
+                    ]
+                    new_data_full = CategoricalChartData.model_validate(
+                        {
+                            "chartType": update.chart_type,
+                            "categories": list(new_categories),
+                            "series": existing_series,
+                            "title": update.title,
+                            "showLegend": update.show_legend,
+                            "showDataLabels": update.show_data_labels,
+                        }
+                    )
+                _validate_categorical(new_data_full)
+                cd = _build_categorical_data(new_data_full)
+            else:
+                # Same-variant scatter type change is impossible (only one scatter type),
+                # but keep the branch for symmetry / future variants.
+                if update.series is None:
+                    series_raw = current_data.get("series", [])
+                    points_per_series = [
+                        [ScatterPoint(x=p["x"], y=p["y"]) for p in s.get("points", [])] for s in series_raw
+                    ]
+                    fallback_series = [
+                        ScatterSeries(
+                            name=series_raw[i].get("name", ""), points=points_per_series[i] or [ScatterPoint(x=0, y=0)]
+                        )
+                        for i in range(len(series_raw))
+                    ] or [ScatterSeries(name="series1", points=[ScatterPoint(x=0, y=0)])]
+                else:
+                    fallback_series = list(update.series)
+                new_scatter = ScatterChartData(
+                    chartType="Scatter",
+                    series=fallback_series,
+                    title=update.title,
+                    showLegend=update.show_legend,
+                    showDataLabels=update.show_data_labels,
+                )
+                _validate_scatter(new_scatter)
+                cd = _build_xy_data(new_scatter)
+
+            x = Emu(int(shape.left or 0))
+            y = Emu(int(shape.top or 0))
+            cx = Emu(int(shape.width or 0))
+            cy = Emu(int(shape.height or 0))
+            sp = shape._element
+            sp.getparent().remove(sp)
+            new_xl = _xl_chart_type(update.chart_type)
+            new_shape = slide.shapes.add_chart(new_xl, x, y, cx, cy, cd)
+            chart = new_shape.chart
+            element_id = _format_element_id(slide_idx, int(new_shape.shape_id))
+            updated_fields.append("chartType")
+            if isinstance(update, CategoricalChartUpdate):
+                if update.categories is not None:
+                    updated_fields.append("categories")
+                if update.series is not None:
+                    updated_fields.append("series")
+            elif update.series is not None:
+                updated_fields.append("series")
+
+        elif isinstance(update, CategoricalChartUpdate):
+            # Same chart type, possibly new data — replace_data() handles in-place.
+            if update.categories is not None or update.series is not None:
+                current_data = _extract_chart_data(chart)
+                new_categories = (
+                    update.categories if update.categories is not None else current_data.get("categories", [])
+                )
+                if update.series is not None:
+                    new_data_full = CategoricalChartData(
+                        chartType=update.chart_type,
+                        categories=list(new_categories),
+                        series=update.series,
+                        title=update.title,
+                        showLegend=update.show_legend,
+                        showDataLabels=update.show_data_labels,
+                    )
+                else:
+                    existing_series_raw = current_data.get("series", [])
+                    existing_series = [
+                        {"name": s.get("name", ""), "values": s.get("values", [])} for s in existing_series_raw
+                    ]
+                    new_data_full = CategoricalChartData.model_validate(
+                        {
+                            "chartType": update.chart_type,
+                            "categories": list(new_categories),
+                            "series": existing_series,
+                            "title": update.title,
+                            "showLegend": update.show_legend,
+                            "showDataLabels": update.show_data_labels,
+                        }
+                    )
+                _validate_categorical(new_data_full)
+                cd = _build_categorical_data(new_data_full)
+                chart.replace_data(cd)
+                if update.categories is not None:
+                    updated_fields.append("categories")
+                if update.series is not None:
+                    updated_fields.append("series")
+
+        else:  # ScatterChartUpdate, same-variant
+            if update.series is not None:
+                new_scatter = ScatterChartData(
+                    chartType="Scatter",
+                    series=update.series,
+                    title=update.title,
+                    showLegend=update.show_legend,
+                    showDataLabels=update.show_data_labels,
+                )
+                _validate_scatter(new_scatter)
+                cd = _build_xy_data(new_scatter)
+                chart.replace_data(cd)
+                updated_fields.append("series")
+
+        title_explicit_none = update.title is None and "title" in update.model_fields_set
+        _apply_display_options(
+            chart,
+            title=update.title,
+            show_legend=update.show_legend,
+            show_data_labels=update.show_data_labels,
+            title_explicit_none=title_explicit_none,
+        )
+        if "title" in update.model_fields_set:
+            updated_fields.append("title")
+        if update.show_legend is not None:
+            updated_fields.append("showLegend")
+        if update.show_data_labels is not None:
+            updated_fields.append("showDataLabels")
+
+    prs.save(str(document_path))
+
+    return {
+        "elementId": element_id,
+        "chartType": target_type,
+        "updatedFields": updated_fields,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers (offload blocking I/O to a worker thread)
+# ---------------------------------------------------------------------------
+
+
+async def insert_chart(
+    document_uri: str,
+    chart_data: CategoricalChartData | ScatterChartData,
+    options: ChartInsertOptions | None,
+) -> dict[str, Any]:
+    """Insert a new chart into the .pptx at ``document_uri``.
+
+    Raises ``ChartEngineError`` (carrying an OASP code) on validation / IO failure.
+    """
+    path = _uri_to_path(document_uri)
+    if isinstance(chart_data, CategoricalChartData):
+        _validate_categorical(chart_data)
+    else:
+        _validate_scatter(chart_data)
+    return await asyncio.to_thread(_insert_chart_blocking, path, chart_data, options)
+
+
+async def get_chart(document_uri: str, element_id: str, slide_index: int | None = None) -> dict[str, Any]:
+    """Read an existing chart's data into the OASP ``ChartData`` wire shape."""
+    path = _uri_to_path(document_uri)
+    return await asyncio.to_thread(_get_chart_blocking, path, element_id, slide_index)
+
+
+async def update_chart(
+    document_uri: str,
+    element_id: str,
+    update: CategoricalChartUpdate | ScatterChartUpdate,
+) -> dict[str, Any]:
+    """Apply a partial update to an existing chart."""
+    path = _uri_to_path(document_uri)
+    return await asyncio.to_thread(_update_chart_blocking, path, element_id, update)

--- a/office4ai/environment/workspace/services/document_lock.py
+++ b/office4ai/environment/workspace/services/document_lock.py
@@ -1,0 +1,58 @@
+"""
+Document-level async lock manager.
+
+Used by the OOXML chart engine to serialize concurrent writes against the same
+.pptx file. The OASP /ppt chart events open and rewrite OOXML directly on disk;
+two concurrent writes would corrupt the package.
+
+Usage::
+
+    async with document_lock_manager.acquire(document_uri):
+        ...  # exclusive OOXML write
+
+The lock is keyed by the *normalized* document URI so that
+``file:///path/foo.pptx`` and ``file://localhost/path/foo.pptx`` share the same
+lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from office4ai.environment.workspace.socketio.services.connection_manager import normalize_document_uri
+
+
+class DocumentLockManager:
+    """Async lock registry keyed by normalized document URI."""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._registry_lock = asyncio.Lock()
+
+    async def _get_or_create(self, document_uri: str) -> asyncio.Lock:
+        key = normalize_document_uri(document_uri)
+        async with self._registry_lock:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            return lock
+
+    @asynccontextmanager
+    async def acquire(self, document_uri: str) -> AsyncIterator[None]:
+        """Acquire the per-document lock for the duration of the ``async with``."""
+        lock = await self._get_or_create(document_uri)
+        async with lock:
+            yield
+
+    def is_locked(self, document_uri: str) -> bool:
+        """Best-effort check (mainly for diagnostics / tests)."""
+        key = normalize_document_uri(document_uri)
+        lock = self._locks.get(key)
+        return bool(lock and lock.locked())
+
+
+# Module-level singleton — chart engine and tests share this instance.
+document_lock_manager = DocumentLockManager()

--- a/office4ai/office/mcp/server.py
+++ b/office4ai/office/mcp/server.py
@@ -112,18 +112,21 @@ class OfficeMCPServer(BaseMCPServer):
             PptAddSlideTool,
             PptDeleteElementTool,
             PptDeleteSlideTool,
+            PptGetChartTool,
             PptGetCurrentSlideElementsTool,
             PptGetSlideElementsTool,
             PptGetSlideInfoTool,
             PptGetSlideLayoutsTool,
             PptGetSlideScreenshotTool,
             PptGotoSlideTool,
+            PptInsertChartTool,
             PptInsertImageTool,
             PptInsertShapeTool,
             PptInsertTableTool,
             PptInsertTextTool,
             PptMoveSlideTool,
             PptReorderElementTool,
+            PptUpdateChartTool,
             PptUpdateElementTool,
             PptUpdateImageTool,
             PptUpdateTableCellTool,
@@ -151,6 +154,10 @@ class OfficeMCPServer(BaseMCPServer):
             PptUpdateTableRowColumnTool(self.workspace),
             PptUpdateTableFormatTool(self.workspace),
             PptUpdateElementTool(self.workspace),
+            # Chart tools (OASP /ppt Draft, v0.2.0 — Server OOXML)
+            PptInsertChartTool(self.workspace),
+            PptGetChartTool(self.workspace),
+            PptUpdateChartTool(self.workspace),
             # Delete & layout tools
             PptDeleteElementTool(self.workspace),
             PptReorderElementTool(self.workspace),
@@ -198,9 +205,14 @@ class OfficeMCPServer(BaseMCPServer):
         connection_manager.register_connect_callback(self._on_doc_connect)
         connection_manager.register_disconnect_callback_ns(self._on_doc_disconnect)
 
+        # Wire Server-side OOXML mutations (e.g. /ppt chart engine) to MCP
+        # resource_updated notifications so subscribers learn the file changed.
+        self.workspace.set_resource_update_callback(self.subscription_manager.notify_fire_and_forget)
+
     async def _async_shutdown(self) -> None:
         """停止 OfficeWorkspace (Socket.IO Server) | Stop OfficeWorkspace"""
         logger.info("停止 OfficeWorkspace | Stopping OfficeWorkspace...")
+        self.workspace.set_resource_update_callback(None)
         self.subscription_manager.clear()
         await self.workspace.stop()
 

--- a/tests/integration_tests/office4ai/office/mcp/test_mcp_protocol.py
+++ b/tests/integration_tests/office4ai/office/mcp/test_mcp_protocol.py
@@ -54,7 +54,8 @@ class TestMCPProtocol:
 
                 # 获取工具列表 | Get tools list
                 tools_result = await session.list_tools()
-                assert len(tools_result.tools) == 46  # 25 Word (21 + 4 OASP v0.2.0 table tools) + 21 PPT
+                # 25 Word (21 + 4 OASP v0.2.0 table tools) + 24 PPT (21 + 3 OASP v0.2.0 chart tools)
+                assert len(tools_result.tools) == 49
 
                 # 验证工具名称前缀 | Verify tool name prefix
                 tool_names = {t.name for t in tools_result.tools}

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
@@ -16,18 +16,21 @@ from office4ai.a2c_smcp.tools.ppt import (
     PptAddSlideTool,
     PptDeleteElementTool,
     PptDeleteSlideTool,
+    PptGetChartTool,
     PptGetCurrentSlideElementsTool,
     PptGetSlideElementsTool,
     PptGetSlideInfoTool,
     PptGetSlideLayoutsTool,
     PptGetSlideScreenshotTool,
     PptGotoSlideTool,
+    PptInsertChartTool,
     PptInsertImageTool,
     PptInsertShapeTool,
     PptInsertTableTool,
     PptInsertTextTool,
     PptMoveSlideTool,
     PptReorderElementTool,
+    PptUpdateChartTool,
     PptUpdateElementTool,
     PptUpdateImageTool,
     PptUpdateTableCellTool,
@@ -73,6 +76,10 @@ class TestToolMetadata:
         (PptUpdateTableRowColumnTool, "ppt_update_table_row_column", "ppt", "update:tableRowColumn"),
         (PptUpdateTableFormatTool, "ppt_update_table_format", "ppt", "update:tableFormat"),
         (PptUpdateElementTool, "ppt_update_element", "ppt", "update:element"),
+        # Chart tools (OASP /ppt Draft, v0.2.0 — Server OOXML)
+        (PptInsertChartTool, "ppt_insert_chart", "ppt", "insert:chart"),
+        (PptGetChartTool, "ppt_get_chart", "ppt", "get:chart"),
+        (PptUpdateChartTool, "ppt_update_chart", "ppt", "update:chart"),
         # Delete & layout tools
         (PptDeleteElementTool, "ppt_delete_element", "ppt", "delete:element"),
         (PptReorderElementTool, "ppt_reorder_element", "ppt", "reorder:element"),
@@ -1004,3 +1011,379 @@ def _extract_types_from_schema(schema: dict) -> set[str]:
             for item in schema[key]:
                 types.update(_extract_types_from_schema(item))
     return types
+
+
+# ============================================================================
+# Chart Tool Tests (OASP /ppt Draft, v0.2.0 — Server OOXML path)
+# ============================================================================
+# These tools override BaseTool.execute() to bypass workspace.execute() and
+# instead drive the OOXML chart engine directly (because Office.js does not
+# expose chart APIs). Tests use a real .pptx fixture so the engine path is
+# exercised end-to-end.
+
+
+class TestChartToolExecute:
+    """End-to-end execute() tests for the 3 chart tools (real .pptx fixture)."""
+
+    @pytest.fixture
+    def deck_uri(self, tmp_path):
+        from pptx import Presentation
+
+        path = tmp_path / "deck.pptx"
+        prs = Presentation()
+        prs.slides.add_slide(prs.slide_layouts[5])
+        prs.slides.add_slide(prs.slide_layouts[5])
+        prs.save(str(path))
+        return path.as_uri()
+
+    @pytest.fixture
+    def workspace_with_notify(self):
+        # Default: no Add-In holding the file → chart writes are allowed.
+        # Tests that exercise the CONNECTED-reject path override this per-test.
+        from office4ai.environment.workspace.base import DocumentStatus
+
+        ws = MagicMock()
+        ws.notify_resource_updated = MagicMock()
+        ws.update_last_activity = MagicMock()
+        ws.get_document_status = MagicMock(return_value=DocumentStatus.DISCONNECTED)
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_insert_chart_returns_element_id_and_fires_notify(self, workspace_with_notify, deck_uri):
+        tool = PptInsertChartTool(workspace_with_notify)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "ColumnClustered",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                    "title": "T",
+                },
+                "options": {"slideIndex": 0},
+            }
+        )
+        assert result["success"] is True
+        assert result["data"]["elementId"].startswith("chart-")
+        assert result["data"]["requiresReload"] is True
+        # Server-OOXML mutations must trigger MCP resource_updated notifications.
+        workspace_with_notify.notify_resource_updated.assert_called_once_with(
+            ["window://office4ai/ppt", "window://office4ai"]
+        )
+        workspace_with_notify.update_last_activity.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_insert_scatter_chart(self, workspace_with_notify, deck_uri):
+        tool = PptInsertChartTool(workspace_with_notify)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Scatter",
+                    "series": [{"name": "ads", "points": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]}],
+                },
+            }
+        )
+        assert result["success"] is True
+        assert result["data"]["chartType"] == "Scatter"
+
+    @pytest.mark.asyncio
+    async def test_insert_dimension_mismatch_returns_3015(self, workspace_with_notify, deck_uri):
+        tool = PptInsertChartTool(workspace_with_notify)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Pie",
+                    "categories": ["A", "B", "C"],
+                    "series": [{"name": "x", "values": [1, 2]}],  # 2 != 3
+                },
+            }
+        )
+        assert result["success"] is False
+        assert "3015" in result["error"]
+        # Failed insert should NOT fire reload notification.
+        workspace_with_notify.notify_resource_updated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_insert_invalid_chart_type_rejected_at_validation(self, workspace_with_notify, deck_uri):
+        tool = PptInsertChartTool(workspace_with_notify)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {"chartType": "Bogus", "categories": [], "series": []},
+            }
+        )
+        assert result["success"] is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_chart_returns_data_without_notify(self, workspace_with_notify, deck_uri):
+        # Insert first to obtain an elementId.
+        i_tool = PptInsertChartTool(workspace_with_notify)
+        ins = await i_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Line",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                    "title": "Trend",
+                },
+            }
+        )
+        eid = ins["data"]["elementId"]
+        workspace_with_notify.notify_resource_updated.reset_mock()
+
+        g_tool = PptGetChartTool(workspace_with_notify)
+        result = await g_tool.execute({"document_uri": deck_uri, "elementId": eid})
+        assert result["success"] is True
+        assert result["data"]["chart"]["chartType"] == "Line"
+        assert result["data"]["chart"]["title"] == "Trend"
+        # Read-only — must not fire reload notification.
+        workspace_with_notify.notify_resource_updated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_chart_int_element_id_coerced(self, workspace_with_notify, deck_uri):
+        # Insert and grab the numeric portion.
+        i_tool = PptInsertChartTool(workspace_with_notify)
+        ins = await i_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Pie",
+                    "categories": ["A"],
+                    "series": [{"name": "x", "values": [1]}],
+                },
+            }
+        )
+        eid = ins["data"]["elementId"]  # "chart-N"
+        # Tool input model coerces int elementId — but here we test str works (default path).
+        g_tool = PptGetChartTool(workspace_with_notify)
+        result = await g_tool.execute({"document_uri": deck_uri, "elementId": eid})
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_chart_unknown_element_returns_3010(self, workspace_with_notify, deck_uri):
+        g_tool = PptGetChartTool(workspace_with_notify)
+        result = await g_tool.execute({"document_uri": deck_uri, "elementId": "chart-99999"})
+        assert result["success"] is False
+        assert "3010" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_chart_title_only(self, workspace_with_notify, deck_uri):
+        i_tool = PptInsertChartTool(workspace_with_notify)
+        ins = await i_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "BarClustered",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                    "title": "Old",
+                },
+            }
+        )
+        eid = ins["data"]["elementId"]
+        workspace_with_notify.notify_resource_updated.reset_mock()
+
+        u_tool = PptUpdateChartTool(workspace_with_notify)
+        result = await u_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": eid,
+                "chart": {"chartType": "BarClustered", "title": "New"},
+            }
+        )
+        assert result["success"] is True
+        assert "title" in result["data"]["updatedFields"]
+        assert result["data"]["requiresReload"] is True
+        workspace_with_notify.notify_resource_updated.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_chart_dimension_mismatch_returns_3015(self, workspace_with_notify, deck_uri):
+        i_tool = PptInsertChartTool(workspace_with_notify)
+        ins = await i_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "ColumnClustered",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                },
+            }
+        )
+        eid = ins["data"]["elementId"]
+
+        u_tool = PptUpdateChartTool(workspace_with_notify)
+        result = await u_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": eid,
+                "chart": {
+                    "chartType": "ColumnClustered",
+                    "categories": ["X", "Y", "Z"],
+                    "series": [{"name": "t", "values": [10, 20]}],  # 2 != 3
+                },
+            }
+        )
+        assert result["success"] is False
+        assert "3015" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_cross_variant_returns_new_element_id(self, workspace_with_notify, deck_uri):
+        i_tool = PptInsertChartTool(workspace_with_notify)
+        ins = await i_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "ColumnClustered",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                },
+            }
+        )
+        old_eid = ins["data"]["elementId"]
+
+        u_tool = PptUpdateChartTool(workspace_with_notify)
+        result = await u_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": old_eid,
+                "chart": {
+                    "chartType": "Scatter",
+                    "series": [{"name": "p", "points": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]}],
+                },
+            }
+        )
+        assert result["success"] is True
+        assert result["data"]["chartType"] == "Scatter"
+        assert "chartType" in result["data"]["updatedFields"]
+        # New chart shape gets a new id; OASP spec returns the latest elementId.
+        new_eid = result["data"]["elementId"]
+        assert new_eid.startswith("chart-")
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_element_returns_3010(self, workspace_with_notify, deck_uri):
+        u_tool = PptUpdateChartTool(workspace_with_notify)
+        result = await u_tool.execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": "chart-99999",
+                "chart": {"chartType": "ColumnClustered", "title": "x"},
+            }
+        )
+        assert result["success"] is False
+        assert "3010" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_insert_missing_document_returns_3001(self, workspace_with_notify):
+        tool = PptInsertChartTool(workspace_with_notify)
+        result = await tool.execute(
+            {
+                "document_uri": "file:///does/not/exist.pptx",
+                "chart": {
+                    "chartType": "Line",
+                    "categories": ["A"],
+                    "series": [{"name": "x", "values": [1]}],
+                },
+            }
+        )
+        assert result["success"] is False
+        assert "3001" in result["error"]
+
+
+# ============================================================================
+# Defense: refuse chart writes when the Add-In holds the document open
+# ============================================================================
+# Empirically verified in manual_tests/ppt/test_chart_e2e.py --mode conflict:
+# when a user has the .pptx open in PowerPoint via the Add-In, any chart that
+# the Server writes to disk is silently overwritten on the next save. The
+# tools refuse the write up-front so the LLM gets a clear error to surface
+# to the user ("please close the document, then retry").
+
+
+class TestChartToolConnectedReject:
+    """Refuse insert/update when document_status == CONNECTED; allow get."""
+
+    @pytest.fixture
+    def deck_uri(self, tmp_path):
+        from pptx import Presentation
+
+        path = tmp_path / "deck.pptx"
+        prs = Presentation()
+        prs.slides.add_slide(prs.slide_layouts[5])
+        prs.save(str(path))
+        return path.as_uri()
+
+    @pytest.fixture
+    def workspace_connected(self):
+        from office4ai.environment.workspace.base import DocumentStatus
+
+        ws = MagicMock()
+        ws.notify_resource_updated = MagicMock()
+        ws.update_last_activity = MagicMock()
+        ws.get_document_status = MagicMock(return_value=DocumentStatus.CONNECTED)
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_insert_chart_refuses_when_connected(self, workspace_connected, deck_uri):
+        tool = PptInsertChartTool(workspace_connected)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Pie",
+                    "categories": ["A", "B"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                },
+            }
+        )
+        assert result["success"] is False
+        assert "3003" in result["error"]
+        # Refuse path must NOT touch disk or fire reload notification.
+        workspace_connected.notify_resource_updated.assert_not_called()
+        workspace_connected.update_last_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_chart_refuses_when_connected(self, workspace_connected, deck_uri):
+        tool = PptUpdateChartTool(workspace_connected)
+        result = await tool.execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": "chart-0-3",
+                "chart": {"chartType": "Pie", "title": "x"},
+            }
+        )
+        assert result["success"] is False
+        assert "3003" in result["error"]
+        workspace_connected.notify_resource_updated.assert_not_called()
+        workspace_connected.update_last_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_chart_NOT_blocked_when_connected(self, workspace_connected, deck_uri):
+        """Read-only tool stays available — at worst it returns stale data."""
+        # Insert via a separate (DISCONNECTED) workspace so we have something to read.
+        from office4ai.environment.workspace.base import DocumentStatus
+
+        writer = MagicMock()
+        writer.notify_resource_updated = MagicMock()
+        writer.update_last_activity = MagicMock()
+        writer.get_document_status = MagicMock(return_value=DocumentStatus.DISCONNECTED)
+        ins = await PptInsertChartTool(writer).execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Line",
+                    "categories": ["A"],
+                    "series": [{"name": "x", "values": [1]}],
+                },
+            }
+        )
+        assert ins["success"]
+        eid = ins["data"]["elementId"]
+
+        # Now flip to CONNECTED state and confirm get_chart still works.
+        result = await PptGetChartTool(workspace_connected).execute({"document_uri": deck_uri, "elementId": eid})
+        assert result["success"] is True
+        assert result["data"]["chart"]["chartType"] == "Line"

--- a/tests/unit_tests/office4ai/environment/workspace/dtos/test_ppt_chart_dtos.py
+++ b/tests/unit_tests/office4ai/environment/workspace/dtos/test_ppt_chart_dtos.py
@@ -1,0 +1,194 @@
+"""Unit tests for PPT chart DTOs (OASP /ppt Draft, v0.2.0)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from office4ai.environment.workspace.dtos.common import ErrorCode, request_registry
+from office4ai.environment.workspace.dtos.ppt import (
+    CategoricalChartData,
+    CategoricalChartUpdate,
+    CategoricalSeries,
+    ChartInsertOptions,
+    PptGetChartRequest,
+    PptInsertChartRequest,
+    PptUpdateChartRequest,
+    ScatterChartData,
+    ScatterChartUpdate,
+    ScatterPoint,
+    ScatterSeries,
+)
+
+
+class TestErrorCodeRegistry:
+    def test_invalid_chart_data_code(self) -> None:
+        assert ErrorCode.INVALID_CHART_DATA == "3015"
+
+    def test_request_registry_has_chart_events(self) -> None:
+        assert request_registry.contains("ppt:insert:chart")
+        assert request_registry.contains("ppt:get:chart")
+        assert request_registry.contains("ppt:update:chart")
+
+
+class TestCategoricalChartData:
+    def test_valid_categorical_data(self) -> None:
+        data = CategoricalChartData(
+            chartType="ColumnClustered",
+            categories=["A", "B"],
+            series=[CategoricalSeries(name="x", values=[1, 2])],
+            title="t",
+            showLegend=True,
+            showDataLabels=False,
+        )
+        assert data.chart_type == "ColumnClustered"
+        assert data.title == "t"
+        # populate_by_name accepts snake_case alongside alias
+        from_snake = CategoricalChartData.model_validate(
+            {
+                "chart_type": "Pie",
+                "categories": ["A"],
+                "series": [{"name": "x", "values": [1]}],
+            }
+        )
+        assert from_snake.chart_type == "Pie"
+
+    def test_to_payload_emits_camel_case(self) -> None:
+        data = CategoricalChartData(
+            chartType="Line",
+            categories=["A"],
+            series=[CategoricalSeries(name="x", values=[1])],
+            showLegend=True,
+        )
+        dumped = data.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["chartType"] == "Line"
+        assert dumped["showLegend"] is True
+        assert "show_legend" not in dumped
+
+    def test_categorical_series_min_one(self) -> None:
+        with pytest.raises(ValidationError):
+            CategoricalChartData(chartType="Pie", categories=["A"], series=[])
+
+
+class TestScatterChartData:
+    def test_valid_scatter_data(self) -> None:
+        data = ScatterChartData(
+            chartType="Scatter",
+            series=[ScatterSeries(name="x", points=[ScatterPoint(x=1, y=2)])],
+        )
+        assert data.chart_type == "Scatter"
+
+    def test_scatter_points_min_one(self) -> None:
+        with pytest.raises(ValidationError):
+            ScatterChartData(
+                chartType="Scatter",
+                series=[ScatterSeries(name="x", points=[])],
+            )
+
+
+class TestPptInsertChartRequest:
+    def test_categorical_request_round_trip(self) -> None:
+        req = PptInsertChartRequest.build(
+            document_uri="file:///t.pptx",
+            chart={
+                "chartType": "BarClustered",
+                "categories": ["A"],
+                "series": [{"name": "s", "values": [1]}],
+            },
+        )
+        payload = req.to_payload()
+        assert payload["documentUri"] == "file:///t.pptx"
+        assert payload["chart"]["chartType"] == "BarClustered"
+
+    def test_scatter_request_discriminator_routes_correctly(self) -> None:
+        req = PptInsertChartRequest.build(
+            document_uri="file:///t.pptx",
+            chart={
+                "chartType": "Scatter",
+                "series": [{"name": "s", "points": [{"x": 1, "y": 2}]}],
+            },
+        )
+        payload = req.to_payload()
+        assert payload["chart"]["chartType"] == "Scatter"
+        assert "categories" not in payload["chart"]
+
+    def test_invalid_chart_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PptInsertChartRequest.build(
+                document_uri="file:///t.pptx",
+                chart={"chartType": "Bogus", "categories": [], "series": []},
+            )
+
+    def test_options_optional(self) -> None:
+        req = PptInsertChartRequest.build(
+            document_uri="file:///t.pptx",
+            chart={
+                "chartType": "Pie",
+                "categories": ["A", "B"],
+                "series": [{"name": "s", "values": [1, 2]}],
+            },
+        )
+        assert req.options is None
+
+
+class TestPptGetChartRequest:
+    def test_minimal_request(self) -> None:
+        req = PptGetChartRequest.build(document_uri="file:///t.pptx", element_id="chart-3")
+        payload = req.to_payload()
+        assert payload["elementId"] == "chart-3"
+        assert "slideIndex" not in payload  # excluded when None
+
+    def test_with_slide_hint(self) -> None:
+        req = PptGetChartRequest.build(document_uri="file:///t.pptx", element_id="chart-3", slide_index=2)
+        payload = req.to_payload()
+        assert payload["slideIndex"] == 2
+
+
+class TestPptUpdateChartRequest:
+    def test_categorical_update_partial(self) -> None:
+        req = PptUpdateChartRequest.build(
+            document_uri="file:///t.pptx",
+            element_id="chart-3",
+            chart={"chartType": "ColumnClustered", "title": "New"},
+        )
+        payload = req.to_payload()
+        assert payload["chart"]["chartType"] == "ColumnClustered"
+        assert payload["chart"]["title"] == "New"
+
+    def test_cross_variant_update(self) -> None:
+        req = PptUpdateChartRequest.build(
+            document_uri="file:///t.pptx",
+            element_id="chart-3",
+            chart={"chartType": "Scatter", "series": [{"name": "x", "points": [{"x": 1, "y": 2}]}]},
+        )
+        payload = req.to_payload()
+        assert payload["chart"]["chartType"] == "Scatter"
+
+
+class TestChartUpdateDiscriminator:
+    def test_categorical_update_constructs(self) -> None:
+        upd = CategoricalChartUpdate(chartType="Pie", title="x")
+        assert upd.chart_type == "Pie"
+
+    def test_scatter_update_constructs(self) -> None:
+        upd = ScatterChartUpdate(chartType="Scatter", title="x")
+        assert upd.chart_type == "Scatter"
+
+
+class TestChartInsertOptionsDefaults:
+    def test_all_optional(self) -> None:
+        opts = ChartInsertOptions()
+        assert opts.slide_index is None
+        assert opts.left is None
+        assert opts.width is None
+
+    def test_validation_positive_dimensions(self) -> None:
+        with pytest.raises(ValidationError):
+            ChartInsertOptions(width=-10)
+        with pytest.raises(ValidationError):
+            ChartInsertOptions(height=0)
+
+    def test_payload_uses_camel_case(self) -> None:
+        opts = ChartInsertOptions(slideIndex=1, width=400)
+        dumped = opts.model_dump(by_alias=True, exclude_none=True)
+        assert dumped == {"slideIndex": 1, "width": 400}

--- a/tests/unit_tests/office4ai/environment/workspace/services/test_chart_engine.py
+++ b/tests/unit_tests/office4ai/environment/workspace/services/test_chart_engine.py
@@ -1,0 +1,313 @@
+"""Unit tests for the OOXML chart engine (insert / get / update)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+from pptx import Presentation
+
+from office4ai.environment.workspace.dtos.common import ErrorCode
+from office4ai.environment.workspace.dtos.ppt import (
+    CategoricalChartData,
+    CategoricalChartUpdate,
+    CategoricalSeries,
+    ChartInsertOptions,
+    ScatterChartData,
+    ScatterChartUpdate,
+    ScatterPoint,
+    ScatterSeries,
+)
+from office4ai.environment.workspace.services import chart_engine
+from office4ai.environment.workspace.services.chart_engine import ChartEngineError
+
+
+@pytest.fixture
+def empty_pptx(tmp_path: Path) -> Path:
+    """A blank 2-slide deck."""
+    path = tmp_path / "deck.pptx"
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[5])
+    prs.slides.add_slide(prs.slide_layouts[5])
+    prs.save(str(path))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# insert_chart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_categorical_chart_returns_element_id(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["Jan", "Feb", "Mar"],
+        series=[CategoricalSeries(name="Rev", values=[100, 200, 150])],
+        title="Q1",
+    )
+    result = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
+    assert result["elementId"].startswith("chart-")
+    assert result["chartType"] == "ColumnClustered"
+    assert result["seriesCount"] == 1
+    assert result["slideIndex"] == 0
+
+
+@pytest.mark.asyncio
+async def test_insert_uses_explicit_geometry(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="Pie",
+        categories=["A", "B"],
+        series=[CategoricalSeries(name="s", values=[1, 2])],
+    )
+    result = await chart_engine.insert_chart(
+        empty_pptx.as_uri(),
+        chart,
+        ChartInsertOptions(slideIndex=1, left=72, top=36, width=400, height=300),
+    )
+    assert math.isclose(result["left"], 72, abs_tol=0.5)
+    assert math.isclose(result["top"], 36, abs_tol=0.5)
+    assert math.isclose(result["width"], 400, abs_tol=0.5)
+    assert math.isclose(result["height"], 300, abs_tol=0.5)
+    assert result["slideIndex"] == 1
+
+
+@pytest.mark.asyncio
+async def test_insert_scatter_chart(empty_pptx: Path) -> None:
+    chart = ScatterChartData(
+        chartType="Scatter",
+        series=[
+            ScatterSeries(
+                name="ads",
+                points=[ScatterPoint(x=1, y=2), ScatterPoint(x=3, y=4)],
+            )
+        ],
+    )
+    result = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
+    assert result["chartType"] == "Scatter"
+    assert result["seriesCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_insert_categorical_dimension_mismatch_raises_3015(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="Pie",
+        categories=["A", "B", "C"],
+        series=[CategoricalSeries(name="x", values=[1, 2])],  # 2 != 3
+    )
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None)
+    assert exc.value.code == ErrorCode.INVALID_CHART_DATA
+
+
+@pytest.mark.asyncio
+async def test_insert_scatter_non_finite_raises_3015(empty_pptx: Path) -> None:
+    chart = ScatterChartData(
+        chartType="Scatter",
+        series=[ScatterSeries(name="s", points=[ScatterPoint(x=float("inf"), y=1)])],
+    )
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None)
+    assert exc.value.code == ErrorCode.INVALID_CHART_DATA
+
+
+@pytest.mark.asyncio
+async def test_insert_unknown_document_uri_raises_3001() -> None:
+    chart = CategoricalChartData(
+        chartType="Line",
+        categories=["A"],
+        series=[CategoricalSeries(name="s", values=[1])],
+    )
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.insert_chart("file:///nonexistent/missing.pptx", chart, None)
+    assert exc.value.code == ErrorCode.DOCUMENT_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_insert_slide_index_out_of_range_raises_4002(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="Line",
+        categories=["A"],
+        series=[CategoricalSeries(name="s", values=[1])],
+    )
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=99))
+    assert exc.value.code == ErrorCode.INVALID_PARAM
+
+
+# ---------------------------------------------------------------------------
+# get_chart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_categorical_round_trip(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["Q1", "Q2"],
+        series=[
+            CategoricalSeries(name="Rev", values=[100, 200]),
+            CategoricalSeries(name="Cost", values=[80, 90]),
+        ],
+        title="Year",
+        showLegend=True,
+    )
+    inserted = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
+    eid = inserted["elementId"]
+
+    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    assert got["elementId"] == eid
+    assert got["chart"]["chartType"] == "ColumnClustered"
+    assert got["chart"]["categories"] == ["Q1", "Q2"]
+    assert got["chart"]["title"] == "Year"
+    assert len(got["chart"]["series"]) == 2
+    assert got["chart"]["series"][0]["name"] == "Rev"
+    assert got["chart"]["series"][0]["values"] == [100.0, 200.0]
+
+
+@pytest.mark.asyncio
+async def test_get_scatter_round_trip(empty_pptx: Path) -> None:
+    chart = ScatterChartData(
+        chartType="Scatter",
+        series=[
+            ScatterSeries(
+                name="ads",
+                points=[ScatterPoint(x=1, y=10), ScatterPoint(x=2, y=20), ScatterPoint(x=3, y=40)],
+            )
+        ],
+        title="adv-vs-sales",
+    )
+    inserted = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
+    got = await chart_engine.get_chart(empty_pptx.as_uri(), inserted["elementId"])
+    assert got["chart"]["chartType"] == "Scatter"
+    assert got["chart"]["title"] == "adv-vs-sales"
+    pts = got["chart"]["series"][0]["points"]
+    assert pts == [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 20.0}, {"x": 3.0, "y": 40.0}]
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_element_raises_3010(empty_pptx: Path) -> None:
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.get_chart(empty_pptx.as_uri(), "chart-99999")
+    assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_get_invalid_element_id_format_raises_3010(empty_pptx: Path) -> None:
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.get_chart(empty_pptx.as_uri(), "shape-1")
+    assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# update_chart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_title_only(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["A", "B"],
+        series=[CategoricalSeries(name="s", values=[1, 2])],
+        title="Original",
+    )
+    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+
+    upd = CategoricalChartUpdate(chartType="ColumnClustered", title="Revised")
+    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    assert "title" in result["updatedFields"]
+
+    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    assert got["chart"]["title"] == "Revised"
+
+
+@pytest.mark.asyncio
+async def test_update_replace_categorical_series(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["A", "B"],
+        series=[CategoricalSeries(name="s", values=[1, 2])],
+    )
+    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+
+    upd = CategoricalChartUpdate(
+        chartType="ColumnClustered",
+        categories=["X", "Y", "Z"],
+        series=[CategoricalSeries(name="t", values=[10, 20, 30])],
+    )
+    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    assert "series" in result["updatedFields"]
+    assert "categories" in result["updatedFields"]
+
+    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    assert got["chart"]["categories"] == ["X", "Y", "Z"]
+    assert got["chart"]["series"][0]["values"] == [10.0, 20.0, 30.0]
+
+
+@pytest.mark.asyncio
+async def test_update_categorical_dimension_mismatch_raises_3015(empty_pptx: Path) -> None:
+    chart = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["A", "B"],
+        series=[CategoricalSeries(name="s", values=[1, 2])],
+    )
+    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None))["elementId"]
+
+    upd = CategoricalChartUpdate(
+        chartType="ColumnClustered",
+        categories=["X", "Y", "Z"],
+        series=[CategoricalSeries(name="t", values=[10, 20])],  # 2 != 3
+    )
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    assert exc.value.code == ErrorCode.INVALID_CHART_DATA
+
+
+@pytest.mark.asyncio
+async def test_cross_variant_categorical_to_scatter(empty_pptx: Path) -> None:
+    cat = CategoricalChartData(
+        chartType="ColumnClustered",
+        categories=["A", "B"],
+        series=[CategoricalSeries(name="s", values=[1, 2])],
+    )
+    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), cat, ChartInsertOptions(slideIndex=0)))["elementId"]
+
+    upd = ScatterChartUpdate(
+        chartType="Scatter",
+        series=[ScatterSeries(name="conv", points=[ScatterPoint(x=1, y=10), ScatterPoint(x=2, y=20)])],
+    )
+    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    assert result["chartType"] == "Scatter"
+    assert "chartType" in result["updatedFields"]
+    assert "series" in result["updatedFields"]
+    new_eid = result["elementId"]
+
+    got = await chart_engine.get_chart(empty_pptx.as_uri(), new_eid)
+    assert got["chart"]["chartType"] == "Scatter"
+
+
+@pytest.mark.asyncio
+async def test_cross_variant_scatter_to_categorical_requires_categories_and_series(
+    empty_pptx: Path,
+) -> None:
+    sc = ScatterChartData(
+        chartType="Scatter",
+        series=[ScatterSeries(name="ads", points=[ScatterPoint(x=1, y=2)])],
+    )
+    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), sc, ChartInsertOptions(slideIndex=0)))["elementId"]
+
+    # Only chartType — no series, no categories — should fail with 3015.
+    upd = CategoricalChartUpdate(chartType="ColumnClustered")
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    assert exc.value.code == ErrorCode.INVALID_CHART_DATA
+
+
+@pytest.mark.asyncio
+async def test_update_unknown_element_raises_3010(empty_pptx: Path) -> None:
+    upd = CategoricalChartUpdate(chartType="ColumnClustered", title="x")
+    with pytest.raises(ChartEngineError) as exc:
+        await chart_engine.update_chart(empty_pptx.as_uri(), "chart-99999", upd)
+    assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND

--- a/tests/unit_tests/office4ai/environment/workspace/services/test_document_lock.py
+++ b/tests/unit_tests/office4ai/environment/workspace/services/test_document_lock.py
@@ -1,0 +1,86 @@
+"""Unit tests for the per-document async lock manager."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from office4ai.environment.workspace.services.document_lock import DocumentLockManager
+
+
+@pytest.mark.asyncio
+async def test_acquire_serializes_concurrent_writes() -> None:
+    """Two coroutines on the same document_uri must run sequentially under the lock."""
+    mgr = DocumentLockManager()
+    uri = "file:///tmp/foo.pptx"
+    order: list[str] = []
+
+    async def writer(label: str, hold: float) -> None:
+        async with mgr.acquire(uri):
+            order.append(f"{label}:enter")
+            await asyncio.sleep(hold)
+            order.append(f"{label}:exit")
+
+    await asyncio.gather(writer("A", 0.05), writer("B", 0.0))
+    # Whoever entered first must exit before the other enters.
+    assert order[0].endswith(":enter")
+    assert order[1].endswith(":exit")
+    assert order[2].endswith(":enter")
+    assert order[3].endswith(":exit")
+    assert order[0].split(":")[0] == order[1].split(":")[0]
+    assert order[2].split(":")[0] == order[3].split(":")[0]
+
+
+@pytest.mark.asyncio
+async def test_different_documents_run_in_parallel() -> None:
+    """Locks for distinct URIs must be independent."""
+    mgr = DocumentLockManager()
+    in_critical: list[str] = []
+
+    async def writer(uri: str, label: str) -> None:
+        async with mgr.acquire(uri):
+            in_critical.append(label)
+            await asyncio.sleep(0.05)
+            in_critical.append(f"{label}:done")
+
+    await asyncio.gather(
+        writer("file:///tmp/a.pptx", "A"),
+        writer("file:///tmp/b.pptx", "B"),
+    )
+    # Both writers should overlap: both labels appear before either *:done.
+    enter_indices = [i for i, x in enumerate(in_critical) if not x.endswith(":done")]
+    done_indices = [i for i, x in enumerate(in_critical) if x.endswith(":done")]
+    assert max(enter_indices) < min(done_indices)
+
+
+@pytest.mark.asyncio
+async def test_normalized_uris_share_lock() -> None:
+    """Different surface forms of the same path must collide on a single lock."""
+    mgr = DocumentLockManager()
+    order: list[str] = []
+
+    async def writer(label: str, uri: str, hold: float) -> None:
+        async with mgr.acquire(uri):
+            order.append(f"{label}:enter")
+            await asyncio.sleep(hold)
+            order.append(f"{label}:exit")
+
+    await asyncio.gather(
+        writer("A", "file:///Users/x/foo.pptx", 0.05),
+        writer("B", "file:///Users/x/foo.pptx", 0.0),
+    )
+    assert order[0].endswith(":enter")
+    assert order[1].endswith(":exit")
+    assert order[2].endswith(":enter")
+    assert order[3].endswith(":exit")
+
+
+@pytest.mark.asyncio
+async def test_is_locked_reports_state() -> None:
+    mgr = DocumentLockManager()
+    uri = "file:///tmp/c.pptx"
+    assert not mgr.is_locked(uri)
+    async with mgr.acquire(uri):
+        assert mgr.is_locked(uri)
+    assert not mgr.is_locked(uri)

--- a/tests/unit_tests/office4ai/office/mcp/test_server.py
+++ b/tests/unit_tests/office4ai/office/mcp/test_server.py
@@ -38,8 +38,8 @@ class TestOfficeMCPServer:
             config = MCPServerConfig()
             server = OfficeMCPServer(config)
 
-            # 25 Word (21 + 4 OASP v0.2.0 table tools) + 21 PPT = 46 tools
-            assert len(server.tools) == 46
+            # 25 Word (21 + 4 OASP v0.2.0 table tools) + 24 PPT (21 + 3 OASP v0.2.0 chart tools) = 49
+            assert len(server.tools) == 49
 
             expected_tools = [
                 # Word Get tools
@@ -91,6 +91,10 @@ class TestOfficeMCPServer:
                 "ppt_update_table_row_column",
                 "ppt_update_table_format",
                 "ppt_update_element",
+                # PPT Chart tools (OASP /ppt Draft, v0.2.0 — Server OOXML)
+                "ppt_insert_chart",
+                "ppt_get_chart",
+                "ppt_update_chart",
                 # PPT Delete & layout tools
                 "ppt_delete_element",
                 "ppt_reorder_element",


### PR DESCRIPTION
## Summary

实装 OASP v0.2.0 协议 3 个 PPT 图表事件对应的 MCP Tools（Server 端 OOXML 离线处理路径），让 AI 可以直接产出柱形图 / 散点图 / 跨 variant 切换等图表能力——**无需 Office.js**（因 Office.js 不暴露 chart 创建/更新接口，参见 [office-js#5463](https://github.com/OfficeDev/office-js/issues/5463)）。

- 新增 3 个 MCP Tools：`ppt_insert_chart` / `ppt_get_chart` / `ppt_update_chart`
- 新增 OOXML chart 引擎（`services/chart_engine.py`）+ 按 documentUri 串行化的文档锁（`services/document_lock.py`）
- 新增冲突防御：`workspace.get_document_status(uri) == CONNECTED` 时写工具返回 `3003`（fail-loud，避免 chart 被 PowerPoint save 静默覆盖）
- PPT 工具数：21 → **24**，总 MCP 工具数：46 → **49**

Closes #9

## Why

OASP v0.2.0（2026-04-30 发版）将 chart 类事件设计为 **Server-handled OOXML** 路径：PowerPoint Office.js API 不支持图表创建/数据更新，所以协议明确规定 Server 端用 `python-pptx` 等工具直接修改 .pptx。本 PR 在 office4ai 完成这条路径的端到端落地。

## What changed

### `office4ai/`

| 文件 | 改动 |
|------|------|
| `environment/workspace/dtos/common.py` | +1 行：新增 `INVALID_CHART_DATA = "3015"` |
| `environment/workspace/dtos/ppt.py` | +191 行：`ChartType` 枚举 / `CategoricalChartData` / `ScatterChartData` / discriminated `ChartData` `ChartUpdate` / `ChartInsertOptions` / 3 组 Request DTO |
| `environment/workspace/office_workspace.py` | +26 行：`set_resource_update_callback` + `notify_resource_updated`（OfficeMCPServer 启动时挂上 subscription_manager）|
| `environment/workspace/services/__init__.py` | 新包 |
| `environment/workspace/services/chart_engine.py` | 新增：OOXML 引擎，10 种 ChartType → `XL_CHART_TYPE` 映射、validate（3015 / 3001 / 3010）、insert / get / update 三个 async API；同 variant 切换 / 跨 variant 切换都走「删旧加新」以绕开 python-pptx `chart.chart_type` 没有 setter 的限制 |
| `environment/workspace/services/document_lock.py` | 新增：`DocumentLockManager`，按规范化的 documentUri 上 asyncio.Lock |
| `a2c_smcp/tools/ppt/{insert,get,update}_chart.py` | 新增：3 个 BaseTool 子类，**写工具 override execute() 直接走 chart_engine，并在入口检查 CONNECTED 状态—命中即返回 3003** |
| `a2c_smcp/tools/ppt/__init__.py` | +6 行注册 |
| `office/mcp/server.py` | +12 行：注册 3 个新工具 + 启动时挂回调（`workspace.set_resource_update_callback(subscription_manager.notify_fire_and_forget)`），停止时清回调 |

### Element ID 设计

`elementId = "chart-<slide_index>-<shape_id>"` —— 因 python-pptx 的 `shape_id` 仅在单张 slide 内唯一，不加 slide 前缀的话两张 slide 上同 shape_id 的 chart 会被错认为同一个。Parser 同时兼容 legacy `chart-<shape_id>` 形式（调用方过渡用）。

### `tests/`

| 文件 | 改动 |
|------|------|
| `unit_tests/office4ai/environment/workspace/dtos/test_ppt_chart_dtos.py` | 新增 19 个用例：discriminated union / alias 往返 / `INVALID_CHART_DATA` 注册 / `ChartInsertOptions` 默认值与正负值校验 |
| `unit_tests/office4ai/environment/workspace/services/test_chart_engine.py` | 新增 17 个用例：分类型 / 散点 round-trip、同 variant 部分更新、跨 variant 切换、3015 / 3010 / 3001 / 4002 错误码 |
| `unit_tests/office4ai/environment/workspace/services/test_document_lock.py` | 新增 4 个用例：同文档串行 / 不同文档并行 / URI 规范化 / `is_locked` 探针 |
| `unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py` | +3 个 chart 工具元数据条目 + 13 个 `TestChartToolExecute` 用例 + 3 个 `TestChartToolConnectedReject` 用例（验证 `insert_chart` / `update_chart` 在 CONNECTED 时返回 3003，`get_chart` 不受影响）|
| `integration_tests/.../test_mcp_protocol.py` + `unit_tests/.../test_server.py` | 工具数 46 → 49 |

### Manual E2E

| 文件 | 用途 |
|-----|------|
| `manual_tests/ppt/test_chart_e2e.py` | 双模式：<br>• `--mode offline`（默认）：MagicMock workspace，跑通 3 工具 + 3 错误码 + OOXML 双重验证<br>• `--mode conflict`：真实 PowerPoint + Add-In 环境的冲突实验，三阶段（Phase A/B 直接调引擎复现冲突；Phase C 走完整工具路径验证 3003 防御 + 引导关闭 + 关闭后写盘 + 重新打开持久化）|
| `docs/manual_tests/ppt_chart_v0.2.0.md` | 视觉验收清单 + Phase A/B/C 真实磁盘 timeline 实测数据 + 已知限制 |

## 冲突实验关键数据（`--mode conflict` 实测）

```
Phase A — Server 写 chart → Add-In 加 image → save
  [A.1 Server chart]        s0=1c/0p
  [A.3 AFTER save]          s0=0c/1p ❗   ← chart 被 PowerPoint save 静默覆盖

Phase B — Add-In image+save → Server chart → Add-In image → save
  [B.2 Server chart]        s1=1c/1p
  [B.4 AFTER save]          s1=0c/2p ❗   ← chart 再次被覆盖

Phase C — 走防御 + 关闭 + 重开
  [C.0 工具调用]             3003 拒绝     ← 防御生效
  [user closes file]        Add-In disconnect (~7s)
  [C.3 工具调用]             成功，s2=1c/0p ← 关闭后放行
  [C.6 reopen + 读盘验证]    s2=1c/0p ✅   ← chart 持久化
```

**结论**：PowerPoint for Mac 的设计就是「打开后磁盘是陈旧快照，save 是 dump 而非 merge」，没有外部文件感知。本 PR 用入口 3003 防御让冲突显式失败而非静默丢数据；后续真正补上 OASP `ppt:notify:reload` 事件 + Add-In 自动重载支持时，去掉这道防御即可零迁移。

## Test plan

- [x] **自动测试**：`uv run poe pre-commit` → ✅ ruff + mypy clean，**949 passed** in 38s（旧 946 + 3 新增 CONNECTED-reject 用例 - 同期 0 回归）
- [x] **Manual `--mode offline`**：3 工具 + 3 错误码 + OOXML 双重验证 全部通过
- [x] **Manual `--mode conflict`**（真实 PowerPoint + Add-In）：
  - [x] Phase A：A.1 写 chart → A.3 save 后 chart 消失（冲突复现）
  - [x] Phase B：B.2 写 chart → B.4 save 后 chart 再次消失（冲突复现）
  - [x] Phase C.0：3003 防御生效
  - [x] Phase C.2：关闭文档后 ~7s 检测到 disconnect
  - [x] Phase C.3：DISCONNECTED 状态下写盘成功
  - [x] Phase C.4：AppleScript 重新打开
  - [x] Phase C.6：reopen 后 chart 持续存在
- [x] **视觉验收**：PowerPoint 中第 3 张幻灯片渲染出柱形图「PHASE-C-CHART」（X 轴 X/Y/Z，1 条 series 值 10/20/30）

## 设计要点（值得 reviewer 关注）

- **CONNECTED 防御**：是 fail-loud 还是 fail-silent 是核心权衡。Phase A/B 实验证明 fail-silent 会丢数据，所以选 fail-loud + 3003 + 文案引导用户关闭。理论上的"在 PPT 已开的情况下能不能 merge"在 macOS 平台无解，故只能拒绝。
- **`update:chart` 跨 variant**：python-pptx 的 `chart.chart_type` 没有 setter，所以不仅是「跨 variant」(Pie ↔ Scatter)，连「同 variant 内部 chart_type 更换」(Pie → ColumnClustered) 也走"删旧加新"路径。新 `elementId` 不同于旧值，AI 必须采纳响应里的新 ID。
- **`requiresReload` flag**：写工具响应中带这个标志 + MCP `resource_updated` 通知；当前 Add-In 没有自动 reload，需要用户手工或下一阶段补 OASP 事件。
- **Draft 标记**：所有 3 个工具 description 显式含 `(OASP /ppt Draft)` 与 3003/3015 行为说明，避免 LLM 误判为稳定契约。

## 跨仓协作

| 仓库 | 状态 |
|------|------|
| `A2C-SMCP/oasp-protocol` v0.2.0（含 chart 事件 + ChartData discriminated union + 3015）| ✅ 已发版 (commit `77d5ffb`, 2026-04-30) |
| `JIAQIA/office4ai`（本 PR）| 🚧 待 review |
| `JIAQIA/office-editor4ai` Add-In | 无需改动（chart 事件不下发到 Office.js） |

后续：开新 Issue 跟踪 OASP `ppt:notify:reload` 扩展 + Add-In 自动重载，届时 PR 内的 CONNECTED 防御可移除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)