### PR TITLE
fix(ppt): 文本边框字段 + 截图发 MCP image 内容类型 (#54, #42)

### DIFF
--- a/office4ai/a2c_smcp/server.py
+++ b/office4ai/a2c_smcp/server.py
@@ -131,7 +131,8 @@ class BaseMCPServer(ABC):
                 affected = self._category_to_resource_uris(tool.category)
                 if affected:
                     await self.subscription_manager.notify_many(affected)
-                return [{"type": "text", "text": str(result)}]
+                # office4ai #42: 委托工具决定 MCP 内容类型 (截图等发 image, 避免 base64 内联 text 撑爆上下文)
+                return tool.to_mcp_content(result)
             except Exception as e:
                 logger.exception(f"工具执行失败 | Tool execution failed: {e}")
                 return [{"type": "text", "text": f"工具执行失败 | Tool execution failed: {e}"}]

--- a/office4ai/a2c_smcp/tools/base.py
+++ b/office4ai/a2c_smcp/tools/base.py
@@ -136,6 +136,17 @@ class BaseTool(ABC):
             return {"success": False, "error": obs.error or "Unknown error"}
         return {"success": True, "data": obs.data}
 
+    def to_mcp_content(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        """将 ``execute()`` 的结果映射为 MCP 内容块 | Map ``execute()`` result to MCP content blocks.
+
+        默认行为: 整个结果序列化为单个 ``text`` 块, 与历史行为逐字一致。
+
+        需要返回大体积二进制/图片载荷的工具 (如截图) **必须** override 本方法, 改发 MCP
+        ``image`` 等内容类型, 否则十余万字符 base64 会被原样内联进 LLM 文本上下文, 撑爆
+        token 触发周期性压缩与死循环 (office4ai #42)。``call_tool`` 据此分发, 不再硬编码 text。
+        """
+        return [{"type": "text", "text": str(result)}]
+
     def validate_input(self, arguments: dict[str, Any], model: type[T]) -> T:
         """Pydantic 输入验证 | Pydantic input validation"""
         return model.model_validate(arguments)

--- a/office4ai/a2c_smcp/tools/ppt/get_slide_screenshot.py
+++ b/office4ai/a2c_smcp/tools/ppt/get_slide_screenshot.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field
 
@@ -21,6 +21,10 @@ class PptGetSlideScreenshotInput(BaseModel):
 
 class PptGetSlideScreenshotTool(BaseTool):
     """获取幻灯片截图"""
+
+    # OASP format → MCP image MIME type (office4ai #42)
+    # 协议 (ScreenshotOptions.format) 只发 png/jpeg; "jpg" 为防御性容错键, 协议层不会命中
+    _FORMAT_MIME_MAP: ClassVar[dict[str, str]] = {"png": "image/png", "jpeg": "image/jpeg", "jpg": "image/jpeg"}
 
     @property
     def name(self) -> str:
@@ -58,3 +62,25 @@ class PptGetSlideScreenshotTool(BaseTool):
         base64_data = obs.data.get("base64", "")
         content = f"Screenshot ({fmt}): {len(base64_data)} chars base64"
         return {"success": True, "content": content, "data": obs.data}
+
+    def to_mcp_content(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        """截图以 MCP ``image`` 内容类型回传, 进入消费方视觉通道而非文本 prompt (office4ai #42)。
+
+        成功且格式已知 → 单个 ``image`` 块 (base64 落在 ``data`` 字段, 不入任何 text)。
+        失败 / 缺 base64 / 未知格式 → 保守回退默认 ``text`` 块, 既保留错误信息又不发错误 MIME。
+        """
+        # 失败: 沿用默认 text (业务返回为 {success, error}, 本就不含 base64)
+        if not result.get("success"):
+            return super().to_mcp_content(result)
+        data = result.get("data") or {}
+        base64_data = data.get("base64") or ""
+        fmt = str(data.get("format") or "").lower()
+        mime = self._FORMAT_MIME_MAP.get(fmt)
+        if base64_data and mime is not None:
+            return [{"type": "image", "data": base64_data, "mimeType": mime}]
+        # 成功但无法作为 image (缺 base64 / 未知格式): 降级 text, 但**绝不**回灌 base64,
+        # 否则未知格式分支会让 #42 根因 (base64 内联文本上下文) 无声复发。
+        suppressed = (
+            f"Screenshot unavailable as image (format={fmt or 'unknown'}, {len(base64_data)} chars base64 suppressed)"
+        )
+        return [{"type": "text", "text": suppressed}]

--- a/office4ai/a2c_smcp/tools/ppt/insert_shape.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_shape.py
@@ -24,7 +24,13 @@ class PptInsertShapeInput(BaseModel):
         "Arrow",
         "Star",
         "TextBox",
-    ] = Field(..., description="Shape type")
+    ] = Field(
+        ...,
+        description=(
+            "Shape type. 'TextBox' is a real text box (no fill, no border). "
+            "Note: 'Line' is currently unreliable (rendered like a rectangle, office-editor4ai #60) — avoid for now."
+        ),
+    )
     options: ShapeInsertOptions | None = Field(None, description="Shape insertion options (position, size, style)")
 
 
@@ -40,8 +46,10 @@ class PptInsertShapeTool(BaseTool):
         return (
             "Insert a geometric shape on a PowerPoint slide. "
             "Supports Rectangle, RoundedRectangle, Circle, Oval, Triangle, "
-            "Line, Arrow, Star, and TextBox shape types. "
-            "Supports optional position, size, fill color, border, and text settings."
+            "Line, Arrow, Star, and TextBox shape types "
+            "(TextBox = a real text box with no fill/border; 'Line' is unreliable, see office-editor4ai #60). "
+            "By default shapes have NO fill and NO border; set fillColor / borderColor (hex) to add them, "
+            "or pass 'none' / borderWidth=0 to explicitly disable. Supports optional position, size, and text."
         )
 
     @property

--- a/office4ai/a2c_smcp/tools/ppt/insert_text.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_text.py
@@ -29,7 +29,9 @@ class PptInsertTextTool(BaseTool):
     def description(self) -> str:
         return (
             "Insert a text box on a PowerPoint slide. "
-            "Supports specifying position, size, font settings, and colors. "
+            "Supports position, size, font settings, font color, and optional fill/border. "
+            "By default the text box has NO fill and NO border (clean look); set fillColor / "
+            "borderColor (hex) to add them, or pass 'none' / borderWidth=0 to keep them off. "
             "Default insertion is on the current slide."
         )
 

--- a/office4ai/environment/workspace/dtos/ppt.py
+++ b/office4ai/environment/workspace/dtos/ppt.py
@@ -179,8 +179,22 @@ class TextInsertOptions(SocketIOBaseModel):
     height: float | None = Field(default=None, description="Height (points)")
     font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
     font_name: str | None = Field(default=None, alias="fontName", description="Font name")
-    color: str | None = Field(default=None, description="Font color (hex)")
-    fill_color: str | None = Field(default=None, alias="fillColor", description="Fill color (hex)")
+    color: str | None = Field(default=None, description="Font color (hex, e.g. '#333333')")
+    fill_color: str | None = Field(
+        default=None,
+        alias="fillColor",
+        description="Text box fill color (hex). Omit for no fill (default); 'none' to explicitly disable.",
+    )
+    border_color: str | None = Field(
+        default=None,
+        alias="borderColor",
+        description="Text box border color (hex). Omit for no border (default); 'none' to explicitly disable.",
+    )
+    border_width: float | None = Field(
+        default=None,
+        alias="borderWidth",
+        description="Text box border width (points). Omit or 0 for no border (default).",
+    )
 
 
 class SlideImageData(SocketIOBaseModel):
@@ -226,9 +240,21 @@ class ShapeInsertOptions(SocketIOBaseModel):
     top: float | None = Field(default=None, description="Top position (points)")
     width: float | None = Field(default=None, description="Width (points)")
     height: float | None = Field(default=None, description="Height (points)")
-    fill_color: str | None = Field(default=None, alias="fillColor", description="Fill color (hex)")
-    border_color: str | None = Field(default=None, alias="borderColor", description="Border color (hex)")
-    border_width: float | None = Field(default=None, alias="borderWidth", description="Border width (points)")
+    fill_color: str | None = Field(
+        default=None,
+        alias="fillColor",
+        description="Fill color (hex). Omit for no fill (default); 'none' to explicitly disable.",
+    )
+    border_color: str | None = Field(
+        default=None,
+        alias="borderColor",
+        description="Border color (hex). Omit for no border (default); 'none' to explicitly disable.",
+    )
+    border_width: float | None = Field(
+        default=None,
+        alias="borderWidth",
+        description="Border width (points). Omit or 0 for no border (default).",
+    )
     text: str | None = Field(default=None, description="Shape text")
 
 

--- a/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
@@ -9,15 +9,24 @@ BaseMCPServer 单元测试 | BaseMCPServer unit tests
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from confz import DataSource
 from mcp.server import NotificationOptions
-from mcp.types import SubscribeRequest, UnsubscribeRequest
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+    ImageContent,
+    SubscribeRequest,
+    TextContent,
+    UnsubscribeRequest,
+)
 
 from office4ai.a2c_smcp.config import MCPServerConfig
 from office4ai.a2c_smcp.server import BaseMCPServer
+from office4ai.a2c_smcp.tools.ppt import PptGetSlideInfoTool, PptGetSlideScreenshotTool
+from office4ai.environment.workspace.base import OfficeObs
 
 
 class ConcreteMCPServer(BaseMCPServer):
@@ -164,3 +173,65 @@ class TestSubscribeCapability:
 
         assert raw_cap.resources is not None
         assert raw_cap.resources.subscribe is False
+
+
+class TestCallToolContentDispatch:
+    """``call_tool`` 内容类型分发回归测试 (office4ai #42)。
+
+    守护根因修复: ``call_tool`` 必须委托 ``tool.to_mcp_content(result)`` 决定 MCP 内容类型,
+    不得再无条件 ``str(result)`` 包成 text。截图工具据此发 ``image`` 块, 否则十余万字符
+    base64 内联进 LLM 文本上下文 → 撑爆 token → 周期性压缩 → 死循环。
+
+    经 ``server.request_handlers[CallToolRequest]`` 触发真实 SDK 分发路径, 端到端覆盖
+    "工具 to_mcp_content → SDK CallToolResult" 这一出口契约。
+    """
+
+    def _make_server(self) -> ConcreteMCPServer:
+        with patch.dict(os.environ, {}, clear=True):
+            return ConcreteMCPServer(MCPServerConfig(), "test-server")
+
+    def _mock_workspace(self, obs: OfficeObs) -> MagicMock:
+        ws = MagicMock()
+        ws.execute = AsyncMock(return_value=obs)
+        return ws
+
+    async def _call(self, server: ConcreteMCPServer, name: str, arguments: dict):
+        handler = server.server.request_handlers[CallToolRequest]
+        req = CallToolRequest(method="tools/call", params=CallToolRequestParams(name=name, arguments=arguments))
+        result = await handler(req)
+        return result.root
+
+    @pytest.mark.asyncio
+    async def test_screenshot_dispatched_as_image_content(self):
+        """核心回归: 截图经 call_tool → MCP image 内容块, base64 落在 data, 不内联进 text。"""
+        server = self._make_server()
+        ws = self._mock_workspace(OfficeObs(success=True, data={"base64": "ABC123", "format": "png"}))
+        tool = PptGetSlideScreenshotTool(ws)
+        server.tools[tool.name] = tool
+
+        call_result = await self._call(
+            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
+        )
+
+        assert call_result.isError is False
+        assert len(call_result.content) == 1
+        block = call_result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.data == "ABC123"
+        assert block.mimeType == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_regular_tool_dispatched_as_text_content(self):
+        """回归保护: 非截图工具仍走默认 text 分支, call_tool 行为不变。"""
+        server = self._make_server()
+        ws = self._mock_workspace(OfficeObs(success=True, data={"slideIndex": 0, "title": "Hello"}))
+        tool = PptGetSlideInfoTool(ws)
+        server.tools[tool.name] = tool
+
+        call_result = await self._call(
+            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
+        )
+
+        assert call_result.isError is False
+        assert len(call_result.content) == 1
+        assert isinstance(call_result.content[0], TextContent)

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
@@ -1759,3 +1759,89 @@ class TestChartRouterPayloadContract:
 
         wrapped = wrap_request("ppt:get:slideOoxml", {"slideIndex": 3}, "file:///t.pptx")
         assert wrapped["slideIndex"] == 3
+
+
+# ============================================================================
+# MCP Content Mapping Tests (office4ai #42)
+# ============================================================================
+
+
+class TestMcpContentMapping:
+    """``to_mcp_content`` 内容类型分发测试 (office4ai #42)。
+
+    守护根因修复: 截图 base64 必须经 MCP ``image`` 内容类型回传, 不得内联进任何 ``text`` 块
+    (否则十余万字符 base64 撑爆 LLM 上下文 → 周期性压缩 → 死循环)。
+    """
+
+    # 一段足够长、可识别的伪 base64, 用于断言「未泄漏进 text」
+    BIG_B64 = "iVBORw0KGgoAAAANSUhEUgAA" + "A" * 2000
+
+    def test_screenshot_success_returns_image_not_text(self, mock_workspace):
+        """复现锚点: PNG 截图成功 → 单个 image 块, base64 在 data, 任何 text 块都不含 base64。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {
+            "success": True,
+            "content": f"Screenshot (png): {len(self.BIG_B64)} chars base64",
+            "data": {"base64": self.BIG_B64, "format": "png"},
+        }
+
+        blocks = tool.to_mcp_content(result)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["data"] == self.BIG_B64
+        assert blocks[0]["mimeType"] == "image/png"
+        # 关键回归断言: base64 不得出现在任何 text 块
+        assert all(self.BIG_B64 not in block.get("text", "") for block in blocks)
+
+    def test_screenshot_jpeg_maps_to_jpeg_mime(self, mock_workspace):
+        """JPEG 截图 → image/jpeg。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "jpeg"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["mimeType"] == "image/jpeg"
+
+    def test_screenshot_failure_falls_back_to_text(self, mock_workspace):
+        """失败 → 回退 text 块 (含 error), 无 image 块。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": False, "error": "render failed"}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "render failed" in blocks[0]["text"]
+
+    def test_screenshot_jpg_fallback_key_maps_to_jpeg_mime(self, mock_workspace):
+        """容错键: 协议虽只发 jpeg, 但 'jpg' 防御性键也应映射 image/jpeg。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "jpg"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["mimeType"] == "image/jpeg"
+
+    def test_screenshot_unknown_format_falls_back_to_text_without_base64(self, mock_workspace):
+        """未知格式 → 保守回退 text, 不发错误 MIME, 且**绝不**把 base64 回灌进 text (#42 根因守护)。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "bmp"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "text"
+        assert not any(block["type"] == "image" for block in blocks)
+        # 回退分支同样守护根因: base64 不得泄漏进任何 text 块
+        assert all(self.BIG_B64 not in block.get("text", "") for block in blocks)
+
+    def test_default_tool_returns_text_unchanged(self, mock_workspace):
+        """回归: 非截图工具沿用默认实现, 单个 text 块且逐字等于 str(result)。"""
+        tool = PptGetSlideInfoTool(mock_workspace)
+        result = {"success": True, "data": {"slideIndex": 0, "title": "Hello"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks == [{"type": "text", "text": str(result)}]


### PR DESCRIPTION
## 背景

PR #41 已关闭，但其中两个 PPT bug 修复仍需落地。本 PR 从 `main` 切出，仅 cherry-pick 这两个 fix 提交（不含 #41 里的整页 OOXML feat 提交）。

## 改动

| 提交 | 内容 |
|------|------|
| `fix(ppt): add text border fields + document none/0 disable semantics (#54)` | 补齐 `TextInsertOptions` 的 `border_color`/`border_width`，并在 DTO/工具描述中澄清 fill/border 的 `none`/`0` = 显式关闭语义；配合 AddIn 侧"不传即不填充/不描边"修复 |
| `fix(ppt): screenshot 发 MCP image 内容类型，杜绝 base64 内联文本上下文 (#42)` | `call_tool` 此前无条件 `str(result)` 把截图十余万字符 base64 内联进 LLM prompt → 单轮 token 飙到 25 万+ → 周期性 compaction 失忆死循环 (P1)。新增 `tools/base.py::to_mcp_content` 钩子（默认逐字兼容历史行为），`get_slide_screenshot` override 发 image 块；失败/未知格式降级 text 且绝不回灌 base64 |

## 改动文件

- `dtos/ppt.py`、`tools/ppt/insert_text.py`、`tools/ppt/insert_shape.py`
- `a2c_smcp/server.py`、`tools/base.py`、`tools/ppt/get_slide_screenshot.py`
- 测试：`test_server_base.py`、`test_ppt_tools.py`

## 验证

- 两次 cherry-pick 无冲突（`server.py`/`base.py` 自动合并）
- 受影响单测全过：**148 passed**

## ⚠️ 上线提醒

`#42` 截图改发 MCP image 的修复，此前在上线侧被 TFRobot 内核误用 `.mime_type` 阻塞（TFROB-594），代码本身无误，合并上线前留意该依赖发版协调。

🤖 Generated with [Claude Code](https://claude.com/claude-code)