### PR TITLE
fix(ppt): screenshot 发 MCP image 内容类型，杜绝 base64 内联文本上下文 (#42)

### DIFF
--- a/office4ai/a2c_smcp/server.py
+++ b/office4ai/a2c_smcp/server.py
@@ -131,7 +131,8 @@ class BaseMCPServer(ABC):
                 affected = self._category_to_resource_uris(tool.category)
                 if affected:
                     await self.subscription_manager.notify_many(affected)
-                return [{"type": "text", "text": str(result)}]
+                # office4ai #42: 委托工具决定 MCP 内容类型 (截图等发 image, 避免 base64 内联 text 撑爆上下文)
+                return tool.to_mcp_content(result)
             except Exception as e:
                 logger.exception(f"工具执行失败 | Tool execution failed: {e}")
                 return [{"type": "text", "text": f"工具执行失败 | Tool execution failed: {e}"}]

--- a/office4ai/a2c_smcp/tools/base.py
+++ b/office4ai/a2c_smcp/tools/base.py
@@ -136,6 +136,17 @@ class BaseTool(ABC):
             return {"success": False, "error": obs.error or "Unknown error"}
         return {"success": True, "data": obs.data}
 
+    def to_mcp_content(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        """将 ``execute()`` 的结果映射为 MCP 内容块 | Map ``execute()`` result to MCP content blocks.
+
+        默认行为: 整个结果序列化为单个 ``text`` 块, 与历史行为逐字一致。
+
+        需要返回大体积二进制/图片载荷的工具 (如截图) **必须** override 本方法, 改发 MCP
+        ``image`` 等内容类型, 否则十余万字符 base64 会被原样内联进 LLM 文本上下文, 撑爆
+        token 触发周期性压缩与死循环 (office4ai #42)。``call_tool`` 据此分发, 不再硬编码 text。
+        """
+        return [{"type": "text", "text": str(result)}]
+
     def validate_input(self, arguments: dict[str, Any], model: type[T]) -> T:
         """Pydantic 输入验证 | Pydantic input validation"""
         return model.model_validate(arguments)

--- a/office4ai/a2c_smcp/tools/ppt/get_slide_screenshot.py
+++ b/office4ai/a2c_smcp/tools/ppt/get_slide_screenshot.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field
 
@@ -21,6 +21,10 @@ class PptGetSlideScreenshotInput(BaseModel):
 
 class PptGetSlideScreenshotTool(BaseTool):
     """获取幻灯片截图"""
+
+    # OASP format → MCP image MIME type (office4ai #42)
+    # 协议 (ScreenshotOptions.format) 只发 png/jpeg; "jpg" 为防御性容错键, 协议层不会命中
+    _FORMAT_MIME_MAP: ClassVar[dict[str, str]] = {"png": "image/png", "jpeg": "image/jpeg", "jpg": "image/jpeg"}
 
     @property
     def name(self) -> str:
@@ -58,3 +62,25 @@ class PptGetSlideScreenshotTool(BaseTool):
         base64_data = obs.data.get("base64", "")
         content = f"Screenshot ({fmt}): {len(base64_data)} chars base64"
         return {"success": True, "content": content, "data": obs.data}
+
+    def to_mcp_content(self, result: dict[str, Any]) -> list[dict[str, Any]]:
+        """截图以 MCP ``image`` 内容类型回传, 进入消费方视觉通道而非文本 prompt (office4ai #42)。
+
+        成功且格式已知 → 单个 ``image`` 块 (base64 落在 ``data`` 字段, 不入任何 text)。
+        失败 / 缺 base64 / 未知格式 → 保守回退默认 ``text`` 块, 既保留错误信息又不发错误 MIME。
+        """
+        # 失败: 沿用默认 text (业务返回为 {success, error}, 本就不含 base64)
+        if not result.get("success"):
+            return super().to_mcp_content(result)
+        data = result.get("data") or {}
+        base64_data = data.get("base64") or ""
+        fmt = str(data.get("format") or "").lower()
+        mime = self._FORMAT_MIME_MAP.get(fmt)
+        if base64_data and mime is not None:
+            return [{"type": "image", "data": base64_data, "mimeType": mime}]
+        # 成功但无法作为 image (缺 base64 / 未知格式): 降级 text, 但**绝不**回灌 base64,
+        # 否则未知格式分支会让 #42 根因 (base64 内联文本上下文) 无声复发。
+        suppressed = (
+            f"Screenshot unavailable as image (format={fmt or 'unknown'}, {len(base64_data)} chars base64 suppressed)"
+        )
+        return [{"type": "text", "text": suppressed}]

--- a/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
@@ -9,15 +9,24 @@ BaseMCPServer 单元测试 | BaseMCPServer unit tests
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from confz import DataSource
 from mcp.server import NotificationOptions
-from mcp.types import SubscribeRequest, UnsubscribeRequest
+from mcp.types import (
+    CallToolRequest,
+    CallToolRequestParams,
+    ImageContent,
+    SubscribeRequest,
+    TextContent,
+    UnsubscribeRequest,
+)
 
 from office4ai.a2c_smcp.config import MCPServerConfig
 from office4ai.a2c_smcp.server import BaseMCPServer
+from office4ai.a2c_smcp.tools.ppt import PptGetSlideInfoTool, PptGetSlideScreenshotTool
+from office4ai.environment.workspace.base import OfficeObs
 
 
 class ConcreteMCPServer(BaseMCPServer):
@@ -164,3 +173,65 @@ class TestSubscribeCapability:
 
         assert raw_cap.resources is not None
         assert raw_cap.resources.subscribe is False
+
+
+class TestCallToolContentDispatch:
+    """``call_tool`` 内容类型分发回归测试 (office4ai #42)。
+
+    守护根因修复: ``call_tool`` 必须委托 ``tool.to_mcp_content(result)`` 决定 MCP 内容类型,
+    不得再无条件 ``str(result)`` 包成 text。截图工具据此发 ``image`` 块, 否则十余万字符
+    base64 内联进 LLM 文本上下文 → 撑爆 token → 周期性压缩 → 死循环。
+
+    经 ``server.request_handlers[CallToolRequest]`` 触发真实 SDK 分发路径, 端到端覆盖
+    "工具 to_mcp_content → SDK CallToolResult" 这一出口契约。
+    """
+
+    def _make_server(self) -> ConcreteMCPServer:
+        with patch.dict(os.environ, {}, clear=True):
+            return ConcreteMCPServer(MCPServerConfig(), "test-server")
+
+    def _mock_workspace(self, obs: OfficeObs) -> MagicMock:
+        ws = MagicMock()
+        ws.execute = AsyncMock(return_value=obs)
+        return ws
+
+    async def _call(self, server: ConcreteMCPServer, name: str, arguments: dict):
+        handler = server.server.request_handlers[CallToolRequest]
+        req = CallToolRequest(method="tools/call", params=CallToolRequestParams(name=name, arguments=arguments))
+        result = await handler(req)
+        return result.root
+
+    @pytest.mark.asyncio
+    async def test_screenshot_dispatched_as_image_content(self):
+        """核心回归: 截图经 call_tool → MCP image 内容块, base64 落在 data, 不内联进 text。"""
+        server = self._make_server()
+        ws = self._mock_workspace(OfficeObs(success=True, data={"base64": "ABC123", "format": "png"}))
+        tool = PptGetSlideScreenshotTool(ws)
+        server.tools[tool.name] = tool
+
+        call_result = await self._call(
+            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
+        )
+
+        assert call_result.isError is False
+        assert len(call_result.content) == 1
+        block = call_result.content[0]
+        assert isinstance(block, ImageContent)
+        assert block.data == "ABC123"
+        assert block.mimeType == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_regular_tool_dispatched_as_text_content(self):
+        """回归保护: 非截图工具仍走默认 text 分支, call_tool 行为不变。"""
+        server = self._make_server()
+        ws = self._mock_workspace(OfficeObs(success=True, data={"slideIndex": 0, "title": "Hello"}))
+        tool = PptGetSlideInfoTool(ws)
+        server.tools[tool.name] = tool
+
+        call_result = await self._call(
+            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
+        )
+
+        assert call_result.isError is False
+        assert len(call_result.content) == 1
+        assert isinstance(call_result.content[0], TextContent)

--- a/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/test_server_base.py
@@ -209,9 +209,7 @@ class TestCallToolContentDispatch:
         tool = PptGetSlideScreenshotTool(ws)
         server.tools[tool.name] = tool
 
-        call_result = await self._call(
-            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
-        )
+        call_result = await self._call(server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0})
 
         assert call_result.isError is False
         assert len(call_result.content) == 1
@@ -228,9 +226,7 @@ class TestCallToolContentDispatch:
         tool = PptGetSlideInfoTool(ws)
         server.tools[tool.name] = tool
 
-        call_result = await self._call(
-            server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0}
-        )
+        call_result = await self._call(server, tool.name, {"document_uri": "file:///t.pptx", "slideIndex": 0})
 
         assert call_result.isError is False
         assert len(call_result.content) == 1

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
@@ -1759,3 +1759,89 @@ class TestChartRouterPayloadContract:
 
         wrapped = wrap_request("ppt:get:slideOoxml", {"slideIndex": 3}, "file:///t.pptx")
         assert wrapped["slideIndex"] == 3
+
+
+# ============================================================================
+# MCP Content Mapping Tests (office4ai #42)
+# ============================================================================
+
+
+class TestMcpContentMapping:
+    """``to_mcp_content`` 内容类型分发测试 (office4ai #42)。
+
+    守护根因修复: 截图 base64 必须经 MCP ``image`` 内容类型回传, 不得内联进任何 ``text`` 块
+    (否则十余万字符 base64 撑爆 LLM 上下文 → 周期性压缩 → 死循环)。
+    """
+
+    # 一段足够长、可识别的伪 base64, 用于断言「未泄漏进 text」
+    BIG_B64 = "iVBORw0KGgoAAAANSUhEUgAA" + "A" * 2000
+
+    def test_screenshot_success_returns_image_not_text(self, mock_workspace):
+        """复现锚点: PNG 截图成功 → 单个 image 块, base64 在 data, 任何 text 块都不含 base64。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {
+            "success": True,
+            "content": f"Screenshot (png): {len(self.BIG_B64)} chars base64",
+            "data": {"base64": self.BIG_B64, "format": "png"},
+        }
+
+        blocks = tool.to_mcp_content(result)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["data"] == self.BIG_B64
+        assert blocks[0]["mimeType"] == "image/png"
+        # 关键回归断言: base64 不得出现在任何 text 块
+        assert all(self.BIG_B64 not in block.get("text", "") for block in blocks)
+
+    def test_screenshot_jpeg_maps_to_jpeg_mime(self, mock_workspace):
+        """JPEG 截图 → image/jpeg。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "jpeg"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["mimeType"] == "image/jpeg"
+
+    def test_screenshot_failure_falls_back_to_text(self, mock_workspace):
+        """失败 → 回退 text 块 (含 error), 无 image 块。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": False, "error": "render failed"}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "render failed" in blocks[0]["text"]
+
+    def test_screenshot_jpg_fallback_key_maps_to_jpeg_mime(self, mock_workspace):
+        """容错键: 协议虽只发 jpeg, 但 'jpg' 防御性键也应映射 image/jpeg。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "jpg"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["mimeType"] == "image/jpeg"
+
+    def test_screenshot_unknown_format_falls_back_to_text_without_base64(self, mock_workspace):
+        """未知格式 → 保守回退 text, 不发错误 MIME, 且**绝不**把 base64 回灌进 text (#42 根因守护)。"""
+        tool = PptGetSlideScreenshotTool(mock_workspace)
+        result = {"success": True, "data": {"base64": self.BIG_B64, "format": "bmp"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks[0]["type"] == "text"
+        assert not any(block["type"] == "image" for block in blocks)
+        # 回退分支同样守护根因: base64 不得泄漏进任何 text 块
+        assert all(self.BIG_B64 not in block.get("text", "") for block in blocks)
+
+    def test_default_tool_returns_text_unchanged(self, mock_workspace):
+        """回归: 非截图工具沿用默认实现, 单个 text 块且逐字等于 str(result)。"""
+        tool = PptGetSlideInfoTool(mock_workspace)
+        result = {"success": True, "data": {"slideIndex": 0, "title": "Hello"}}
+
+        blocks = tool.to_mcp_content(result)
+
+        assert blocks == [{"type": "text", "text": str(result)}]


### PR DESCRIPTION
> 优先级：**P1**。原 PR #41 已关闭，本修复独立拆出提交。

## 问题

`call_tool` 此前对所有工具无条件 `str(result)` 包成 text 内容块，截图十余万字符 base64 被原样内联进 LLM prompt → 单轮 token 飙到 25 万+ → 触发周期性 compaction 失忆 → Agent 反复重新截图/读元素，单任务死循环不收敛。

## 修复

MCP 协议本就提供 image 内容类型、消费方也已按 type 分流，缺口纯在 office4ai 出口侧。在正确抽象层消除根因：

- `tools/base.py`: 新增 `to_mcp_content` 钩子，默认 `[{"type":"text","text":str(result)}]`，与历史行为逐字一致，其余工具零回归
- `tools/ppt/get_slide_screenshot.py`: override 钩子，成功 + 已知格式发 image 块（base64 落 data，不入 text）；失败/未知格式降级 text 且绝不回灌 base64
- `server.py`: `call_tool` 委托 `tool.to_mcp_content(result)`，退化为纯分发器
- 测试：工具层映射 6 例 + server 经真实 SDK 分发路径端到端守护 2 例

## ⚠️ 上线提醒

此前在上线侧被 TFRobot 内核误用 `.mime_type` 阻塞（TFROB-594），代码本身无误，合并上线前留意该依赖发版协调。

🤖 Generated with [Claude Code](https://claude.com/claude-code)