### PR TITLE
fix(ppt): add text border fields + document none/0 disable semantics (#54)

### DIFF
--- a/office4ai/a2c_smcp/tools/ppt/insert_shape.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_shape.py
@@ -24,7 +24,13 @@ class PptInsertShapeInput(BaseModel):
         "Arrow",
         "Star",
         "TextBox",
-    ] = Field(..., description="Shape type")
+    ] = Field(
+        ...,
+        description=(
+            "Shape type. 'TextBox' is a real text box (no fill, no border). "
+            "Note: 'Line' is currently unreliable (rendered like a rectangle, office-editor4ai #60) — avoid for now."
+        ),
+    )
     options: ShapeInsertOptions | None = Field(None, description="Shape insertion options (position, size, style)")
 
 
@@ -40,8 +46,10 @@ class PptInsertShapeTool(BaseTool):
         return (
             "Insert a geometric shape on a PowerPoint slide. "
             "Supports Rectangle, RoundedRectangle, Circle, Oval, Triangle, "
-            "Line, Arrow, Star, and TextBox shape types. "
-            "Supports optional position, size, fill color, border, and text settings."
+            "Line, Arrow, Star, and TextBox shape types "
+            "(TextBox = a real text box with no fill/border; 'Line' is unreliable, see office-editor4ai #60). "
+            "By default shapes have NO fill and NO border; set fillColor / borderColor (hex) to add them, "
+            "or pass 'none' / borderWidth=0 to explicitly disable. Supports optional position, size, and text."
         )
 
     @property

--- a/office4ai/a2c_smcp/tools/ppt/insert_text.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_text.py
@@ -29,7 +29,9 @@ class PptInsertTextTool(BaseTool):
     def description(self) -> str:
         return (
             "Insert a text box on a PowerPoint slide. "
-            "Supports specifying position, size, font settings, and colors. "
+            "Supports position, size, font settings, font color, and optional fill/border. "
+            "By default the text box has NO fill and NO border (clean look); set fillColor / "
+            "borderColor (hex) to add them, or pass 'none' / borderWidth=0 to keep them off. "
             "Default insertion is on the current slide."
         )
 

--- a/office4ai/environment/workspace/dtos/ppt.py
+++ b/office4ai/environment/workspace/dtos/ppt.py
@@ -179,8 +179,22 @@ class TextInsertOptions(SocketIOBaseModel):
     height: float | None = Field(default=None, description="Height (points)")
     font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
     font_name: str | None = Field(default=None, alias="fontName", description="Font name")
-    color: str | None = Field(default=None, description="Font color (hex)")
-    fill_color: str | None = Field(default=None, alias="fillColor", description="Fill color (hex)")
+    color: str | None = Field(default=None, description="Font color (hex, e.g. '#333333')")
+    fill_color: str | None = Field(
+        default=None,
+        alias="fillColor",
+        description="Text box fill color (hex). Omit for no fill (default); 'none' to explicitly disable.",
+    )
+    border_color: str | None = Field(
+        default=None,
+        alias="borderColor",
+        description="Text box border color (hex). Omit for no border (default); 'none' to explicitly disable.",
+    )
+    border_width: float | None = Field(
+        default=None,
+        alias="borderWidth",
+        description="Text box border width (points). Omit or 0 for no border (default).",
+    )
 
 
 class SlideImageData(SocketIOBaseModel):
@@ -226,9 +240,21 @@ class ShapeInsertOptions(SocketIOBaseModel):
     top: float | None = Field(default=None, description="Top position (points)")
     width: float | None = Field(default=None, description="Width (points)")
     height: float | None = Field(default=None, description="Height (points)")
-    fill_color: str | None = Field(default=None, alias="fillColor", description="Fill color (hex)")
-    border_color: str | None = Field(default=None, alias="borderColor", description="Border color (hex)")
-    border_width: float | None = Field(default=None, alias="borderWidth", description="Border width (points)")
+    fill_color: str | None = Field(
+        default=None,
+        alias="fillColor",
+        description="Fill color (hex). Omit for no fill (default); 'none' to explicitly disable.",
+    )
+    border_color: str | None = Field(
+        default=None,
+        alias="borderColor",
+        description="Border color (hex). Omit for no border (default); 'none' to explicitly disable.",
+    )
+    border_width: float | None = Field(
+        default=None,
+        alias="borderWidth",
+        description="Border width (points). Omit or 0 for no border (default).",
+    )
     text: str | None = Field(default=None, description="Shape text")
 
 


### PR DESCRIPTION
> 原 PR #41 已关闭，本修复独立拆出提交。

## 改动

补齐文本边框能力并澄清默认语义，配合 AddIn 侧"不传即不填充/不描边"的修复。经核实：office4ai 的 DTO 颜色字段本就全是 `default=None`、工具层纯声明式（`exclude_none`），从无硬编码 white/black/蓝 —— AddIn 修复不会被上游覆盖。

- `dtos/ppt.py`: `TextInsertOptions` 补 `border_color`/`border_width`（`fill_color` 原已有；映射 OASP `borderColor`/`borderWidth`，AddIn 已端到端支持：schema→handler(border→line)→textInsertion.applyLine）
- `dtos/ppt.py`: Text/Shape 的 fill/border 描述加 `none`/`0` = 显式关闭语义
- `insert_text.py` / `insert_shape.py`: 工具描述写明默认无填充无边框、可设/可关；TextBox = 真文本框；Line 不可靠（标注 office-editor4ai #60）

🤖 Generated with [Claude Code](https://claude.com/claude-code)