### PR TITLE
refactor(ppt): F1 删除 chart Path A 离线路径 (#68)

### DIFF
--- a/office4ai/a2c_smcp/tools/base.py
+++ b/office4ai/a2c_smcp/tools/base.py
@@ -82,9 +82,9 @@ class BaseTool(ABC):
 
         默认按 ``category`` 派生：``word``/``ppt``/``excel`` 平台工具依赖对应 Add-In 连接
         （``True``）；``authoring`` 等 standalone 工具（如 ``office_run_script``）常驻
-        （``False``），无连接也暴露。chart 工具（``category='ppt'``）经此默认即 ``True``——
-        即便有 Path A 离线能力，也按 W4a 二元模型随连接收敛；Path A 代码删除见 F1(#68)。
-        子类如需背离 category 语义可 override 本属性。
+        （``False``），无连接也暴露。chart 工具（``category='ppt'``）经此默认即 ``True``，
+        按 W4a 二元模型随连接收敛；其离线路径（旧 Path A）已在 F1(#68) 删除，脱机改图
+        改由 authoring 流水线（``office_run_script``）承接。子类如需背离 category 语义可 override 本属性。
         """
         return self.category != "authoring"
 

--- a/office4ai/a2c_smcp/tools/ppt/get_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/get_chart.py
@@ -1,4 +1,4 @@
-"""ppt_get_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+"""ppt_get_chart MCP Tool (OASP /ppt Draft — Server OOXML, connected-only)."""
 
 from __future__ import annotations
 
@@ -8,24 +8,26 @@ from pydantic import BaseModel, Field, field_validator
 
 from office4ai.a2c_smcp.tools.base import BaseTool
 from office4ai.environment.workspace.base import DocumentStatus
-from office4ai.environment.workspace.services import chart_engine, chart_router
+from office4ai.environment.workspace.services import chart_router
 from office4ai.environment.workspace.services.chart_engine import ChartEngineError
 from office4ai.environment.workspace.services.document_lock import document_lock_manager
 
 
 class PptGetChartInput(BaseModel):
-    """MCP 输入模型：读取已存在图表的当前数据（Server 端 OOXML 离线处理）。"""
+    """MCP 输入模型：读取已存在图表的当前数据（Server 端 OOXML，连接态客户端往返）。"""
 
     document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
     element_id: str | int = Field(
         ...,
         alias="elementId",
-        description=("Chart element ID returned by ppt_insert_chart (format: 'chart-<shape_id>'). Required."),
+        description=(
+            "Chart element ID returned by ppt_insert_chart (opaque string, e.g. 'oasp-chart-<uuid>'). Required."
+        ),
     )
     slide_index: int | None = Field(
         default=None,
         alias="slideIndex",
-        description="Optional slide hint to speed up lookup (0-based); elementId remains authoritative.",
+        description="Slide index (0-based) of the chart's slide. REQUIRED — the live round-trip exports that slide to read it.",
         ge=0,
     )
 
@@ -39,7 +41,7 @@ class PptGetChartInput(BaseModel):
 
 
 class PptGetChartTool(BaseTool):
-    """Read an existing chart's data (OASP /ppt Draft, Server OOXML)."""
+    """Read an existing chart's data (OASP /ppt Draft, Server OOXML, connected-only)."""
 
     @property
     def name(self) -> str:
@@ -49,9 +51,10 @@ class PptGetChartTool(BaseTool):
     def description(self) -> str:
         return (
             "Read an existing PowerPoint chart's logical data and display options "
-            "(OASP /ppt Draft, dual-path — chart OOXML is parsed Server-side). "
-            "When the document is OPEN in PowerPoint and slideIndex is supplied, the Server reads the "
-            "live (possibly unsaved) slide via a client round-trip; otherwise it reads the .pptx on disk. "
+            "(OASP /ppt Draft — chart OOXML is parsed Server-side). Requires the target document OPEN "
+            "in PowerPoint via the Add-In, with slideIndex supplied: the Server reads the live (possibly "
+            "unsaved) slide via a client round-trip. For a CLOSED .pptx this returns 3003 — read the "
+            "chart offline with the authoring pipeline (office_run_script + python-pptx) instead. "
             "Returns chartType, categories/points, series, title, showLegend, showDataLabels, "
             "and geometry (left/top/width/height in points). Inspect chartType FIRST: "
             "categorical types expose 'categories' + 'series[].values'; Scatter exposes 'series[].points'. "
@@ -75,11 +78,7 @@ class PptGetChartTool(BaseTool):
         return PptGetChartInput
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """Dual-path route (#15): CONNECTED + slideIndex → live round-trip; else on-disk read.
-
-        Read-only, so reactive degradation falls back to the on-disk read (at worst stale data)
-        rather than erroring — the same behaviour as reading a connected document in 0.2.0.
-        """
+        """Connected-only (#68): CONNECTED + slideIndex → live round-trip read; else refuse."""
         try:
             validated = self.validate_input(arguments, PptGetChartInput)
         except ValueError as e:
@@ -87,27 +86,19 @@ class PptGetChartTool(BaseTool):
 
         document_uri = validated.document_uri
         element_id = str(validated.element_id)
-        connected = self.workspace.get_document_status(document_uri) == DocumentStatus.CONNECTED
+        # Offline chart reads are served by the authoring pipeline, not this tool (Path A removed, #68).
+        if self.workspace.get_document_status(document_uri) != DocumentStatus.CONNECTED:
+            return {"success": False, "error": chart_router.OFFLINE_MESSAGE}
+        if validated.slide_index is None:
+            return {"success": False, "error": chart_router.LIVE_NEEDS_SLIDE_INDEX}
         async with document_lock_manager.acquire(document_uri):
             try:
-                if connected and validated.slide_index is not None:
-                    try:
-                        result_data = await chart_router.get_chart_path_b(
-                            self.workspace, document_uri, element_id, validated.slide_index
-                        )
-                    except chart_router.PathBUnavailable:
-                        # Read-only degradation: fall back to the on-disk read.
-                        result_data = await chart_engine.get_chart(
-                            document_uri=document_uri,
-                            element_id=element_id,
-                            slide_index=validated.slide_index,
-                        )
-                else:
-                    result_data = await chart_engine.get_chart(
-                        document_uri=document_uri,
-                        element_id=element_id,
-                        slide_index=validated.slide_index,
-                    )
+                result_data = await chart_router.get_chart_path_b(
+                    self.workspace, document_uri, element_id, validated.slide_index
+                )
+            except chart_router.PathBUnavailable:
+                # Live read path not available yet → offline-authoring guidance (no on-disk fallback, #68).
+                return {"success": False, "error": chart_router.DEGRADE_MESSAGE}
             except ChartEngineError as e:
                 return {"success": False, "error": str(e)}
             except Exception as e:  # noqa: BLE001

--- a/office4ai/a2c_smcp/tools/ppt/insert_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_chart.py
@@ -1,4 +1,4 @@
-"""ppt_insert_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+"""ppt_insert_chart MCP Tool (OASP /ppt Draft — Server OOXML, connected-only)."""
 
 from __future__ import annotations
 
@@ -14,13 +14,13 @@ from office4ai.environment.workspace.dtos.ppt import (
     ChartInsertOptions,
     ScatterChartData,
 )
-from office4ai.environment.workspace.services import chart_engine, chart_router
+from office4ai.environment.workspace.services import chart_router
 from office4ai.environment.workspace.services.chart_engine import ChartEngineError
 from office4ai.environment.workspace.services.document_lock import document_lock_manager
 
 
 class PptInsertChartInput(BaseModel):
-    """MCP 输入模型：在指定 .pptx 中插入图表（Server 端 OOXML 离线处理）。"""
+    """MCP 输入模型：在打开的文档中插入图表（Server 端 OOXML，连接态客户端往返）。"""
 
     document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
     chart: CategoricalChartData | ScatterChartData = Field(
@@ -33,7 +33,7 @@ class PptInsertChartInput(BaseModel):
     )
     options: ChartInsertOptions | None = Field(
         default=None,
-        description="Geometry & target slide (optional). Defaults: slideIndex=current, 480x320pt centered.",
+        description="Geometry & target slide (optional). Defaults: slideIndex=0, 480x320pt centered.",
     )
 
 
@@ -48,13 +48,14 @@ class PptInsertChartTool(BaseTool):
     def description(self) -> str:
         return (
             "Insert a chart (column/bar/line/pie/scatter/...) into a PowerPoint slide "
-            "(OASP /ppt Draft, dual-path — all chart OOXML is built Server-side). "
-            "When the document is CLOSED, the Server edits the .pptx on disk; when it is OPEN in "
-            "PowerPoint via the Add-In, the Server applies the chart to the live slide through a "
-            "client round-trip. While the Add-In round-trip handler is not yet available it may "
-            "return 3003 (close the document, then retry); this lifts automatically once it ships. "
-            "Expect >1s latency. After an on-disk write the document must be reopened to render the new "
-            "chart (an MCP resource_updated notification is fired to /ppt subscribers). "
+            "(OASP /ppt Draft — all chart OOXML is built Server-side). Requires the target "
+            "document OPEN in PowerPoint via the Add-In: the Server applies the chart to the live "
+            "slide through a client round-trip. For a CLOSED .pptx this returns 3003 — build the "
+            "chart offline with the authoring pipeline (office_run_script + python-pptx) instead. "
+            "While the Add-In round-trip handler is not yet available a CONNECTED call may also "
+            "return 3003 (close the document and use office_run_script); this lifts automatically "
+            "once it ships. Expect >1s latency. The live round-trip updates the open document in "
+            "place (an MCP resource_updated notification is fired to /ppt subscribers). "
             "ChartType discriminates the schema: categorical types (ColumnClustered/ColumnStacked/"
             "BarClustered/Line/LineMarkers/Pie/Doughnut/Area/Radar) require categories + "
             "series[].values; Scatter requires series[].points = [{x, y}]. "
@@ -78,36 +79,31 @@ class PptInsertChartTool(BaseTool):
         return PptInsertChartInput
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """Dual-path route (#15): CONNECTED → client round-trip; DISCONNECTED → on-disk OOXML."""
+        """Connected-only (#68): CONNECTED → live client round-trip; DISCONNECTED → refuse."""
         try:
             validated = self.validate_input(arguments, PptInsertChartInput)
         except ValueError as e:
             return {"success": False, "error": str(e)}
 
         document_uri = validated.document_uri
-        connected = self.workspace.get_document_status(document_uri) == DocumentStatus.CONNECTED
+        # Offline chart work is served by the authoring pipeline, not this tool (Path A removed, #68).
+        if self.workspace.get_document_status(document_uri) != DocumentStatus.CONNECTED:
+            return {"success": False, "error": chart_router.OFFLINE_MESSAGE}
         async with document_lock_manager.acquire(document_uri):
             try:
-                if connected:
-                    result_data = await chart_router.insert_chart_path_b(
-                        self.workspace, document_uri, validated.chart, validated.options
-                    )
-                else:
-                    result_data = await chart_engine.insert_chart(
-                        document_uri=document_uri,
-                        chart_data=validated.chart,
-                        options=validated.options,
-                    )
+                result_data = await chart_router.insert_chart_path_b(
+                    self.workspace, document_uri, validated.chart, validated.options
+                )
             except chart_router.PathBUnavailable:
-                # Reactive degradation: path B not available yet → flipped 3003 guidance.
-                return {"success": False, "error": chart_router.DEGRADE_MESSAGE_WRITE}
+                # Reactive degradation: live round-trip not available yet → offline-authoring guidance.
+                return {"success": False, "error": chart_router.DEGRADE_MESSAGE}
             except ChartEngineError as e:
                 return {"success": False, "error": str(e)}
-            except Exception as e:  # noqa: BLE001 - surface unexpected I/O errors as 3004
+            except Exception as e:  # noqa: BLE001 - surface unexpected errors as 3004
                 return {"success": False, "error": f"3004: {e}"}
 
-        # On-disk writes change the file (reopen to render); live round-trips already updated it.
-        result_data["requiresReload"] = not connected
+        # The live round-trip already updated the open document → no reopen needed.
+        result_data["requiresReload"] = False
         self.workspace.update_last_activity(
             document_uri=document_uri,
             tool_name=self.name,

--- a/office4ai/a2c_smcp/tools/ppt/update_chart.py
+++ b/office4ai/a2c_smcp/tools/ppt/update_chart.py
@@ -1,4 +1,4 @@
-"""ppt_update_chart MCP Tool (OASP /ppt Draft, v0.2.0 — Server OOXML)."""
+"""ppt_update_chart MCP Tool (OASP /ppt Draft — Server OOXML, connected-only)."""
 
 from __future__ import annotations
 
@@ -13,19 +13,19 @@ from office4ai.environment.workspace.dtos.ppt import (
     CategoricalChartUpdate,
     ScatterChartUpdate,
 )
-from office4ai.environment.workspace.services import chart_engine, chart_router
+from office4ai.environment.workspace.services import chart_router
 from office4ai.environment.workspace.services.chart_engine import ChartEngineError
 from office4ai.environment.workspace.services.document_lock import document_lock_manager
 
 
 class PptUpdateChartInput(BaseModel):
-    """MCP 输入模型：更新已存在图表（Server 端 OOXML 离线处理）。"""
+    """MCP 输入模型：更新已存在图表（Server 端 OOXML，连接态客户端往返）。"""
 
     document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/deck.pptx)")
     element_id: str | int = Field(
         ...,
         alias="elementId",
-        description="Chart element ID (format: 'chart-<shape_id>')",
+        description="Chart element ID (opaque string, e.g. 'oasp-chart-<uuid>')",
     )
     chart: CategoricalChartUpdate | ScatterChartUpdate = Field(
         ...,
@@ -41,9 +41,8 @@ class PptUpdateChartInput(BaseModel):
         default=None,
         alias="slideIndex",
         description=(
-            "Slide index (0-based) of the chart. Optional on disk (elementId locates the chart), "
-            "but REQUIRED to update a chart while the document is open in PowerPoint — the live "
-            "round-trip exports that slide. Reuse the slideIndex returned by ppt_get_chart."
+            "Slide index (0-based) of the chart. REQUIRED — the live round-trip exports that "
+            "slide to apply the update. Reuse the slideIndex returned by ppt_get_chart."
         ),
         ge=0,
     )
@@ -67,14 +66,15 @@ class PptUpdateChartTool(BaseTool):
     def description(self) -> str:
         return (
             "Update an existing PowerPoint chart in-place via OOXML rewriting "
-            "(OASP /ppt Draft, dual-path — all chart OOXML is built Server-side). "
-            "When the document is CLOSED, the Server edits the .pptx on disk; when it is OPEN in "
-            "PowerPoint via the Add-In, the Server applies the change to the live slide through a "
-            "client round-trip (pass slideIndex — reuse the one from ppt_get_chart). While the Add-In "
-            "round-trip handler is not yet available it may return 3003 (close the document, then "
-            "retry); this lifts automatically once it ships. "
+            "(OASP /ppt Draft — all chart OOXML is built Server-side). Requires the target document "
+            "OPEN in PowerPoint via the Add-In: the Server applies the change to the live slide through "
+            "a client round-trip (pass slideIndex — reuse the one from ppt_get_chart). For a CLOSED "
+            ".pptx this returns 3003 — edit the chart offline with the authoring pipeline "
+            "(office_run_script + python-pptx) instead. While the Add-In round-trip handler is not yet "
+            "available a CONNECTED call may also return 3003 (close the document and use "
+            "office_run_script); this lifts automatically once it ships. "
             "Expect >1s latency; concurrent updates on the same document are serialized. "
-            "After an on-disk write an MCP resource_updated notification is fired; reopen the deck to see it. "
+            "The live round-trip updates the open document in place (an MCP resource_updated notification is fired). "
             "chartType is the REQUIRED discriminator — call ppt_get_chart first to read it. "
             "title=null deletes the title; explicit null is preserved on the wire. "
             "Cross-variant switches (e.g. Pie → Scatter) MUST include compatible series, "
@@ -99,7 +99,7 @@ class PptUpdateChartTool(BaseTool):
         return PptUpdateChartInput
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """Dual-path route (#15): CONNECTED → client round-trip; DISCONNECTED → on-disk OOXML."""
+        """Connected-only (#68): CONNECTED live round-trip; DISCONNECTED → refuse."""
         try:
             validated = self.validate_input(arguments, PptUpdateChartInput)
         except ValueError as e:
@@ -107,32 +107,26 @@ class PptUpdateChartTool(BaseTool):
 
         document_uri = validated.document_uri
         element_id = str(validated.element_id)
-        connected = self.workspace.get_document_status(document_uri) == DocumentStatus.CONNECTED
+        # Offline chart work is served by the authoring pipeline, not this tool (Path A removed, #68).
+        if self.workspace.get_document_status(document_uri) != DocumentStatus.CONNECTED:
+            return {"success": False, "error": chart_router.OFFLINE_MESSAGE}
+        # The live round-trip must export a specific slide; without slideIndex it cannot route.
+        if validated.slide_index is None:
+            return {"success": False, "error": chart_router.LIVE_NEEDS_SLIDE_INDEX}
         async with document_lock_manager.acquire(document_uri):
             try:
-                if connected:
-                    # Path B needs the slide to export; without it we cannot safely route an
-                    # open-document write (on-disk would be overwritten) → degrade up-front.
-                    if validated.slide_index is None:
-                        return {"success": False, "error": chart_router.DEGRADE_MESSAGE_WRITE}
-                    result_data = await chart_router.update_chart_path_b(
-                        self.workspace, document_uri, element_id, validated.chart, validated.slide_index
-                    )
-                else:
-                    result_data = await chart_engine.update_chart(
-                        document_uri=document_uri,
-                        element_id=element_id,
-                        update=validated.chart,
-                    )
+                result_data = await chart_router.update_chart_path_b(
+                    self.workspace, document_uri, element_id, validated.chart, validated.slide_index
+                )
             except chart_router.PathBUnavailable:
-                # Reactive degradation: path B not available yet → flipped 3003 guidance.
-                return {"success": False, "error": chart_router.DEGRADE_MESSAGE_WRITE}
+                # Reactive degradation: live round-trip not available yet → offline-authoring guidance.
+                return {"success": False, "error": chart_router.DEGRADE_MESSAGE}
             except ChartEngineError as e:
                 return {"success": False, "error": str(e)}
             except Exception as e:  # noqa: BLE001
                 return {"success": False, "error": f"3004: {e}"}
 
-        result_data["requiresReload"] = not connected
+        result_data["requiresReload"] = False
         self.workspace.update_last_activity(
             document_uri=document_uri,
             tool_name=self.name,

--- a/office4ai/environment/workspace/services/chart_engine.py
+++ b/office4ai/environment/workspace/services/chart_engine.py
@@ -6,37 +6,33 @@ office-js#5463). The OASP protocol therefore routes ppt:insert:chart /
 ppt:get:chart / ppt:update:chart through this Server-side engine, which builds
 and mutates the .pptx OOXML directly via ``python-pptx``.
 
-Two execution modes share one OOXML core
-========================================
-- **Path A — on-disk (closed document):** load/modify/save a ``.pptx`` file on
-  disk. This is the original 0.2.0 behaviour and is preserved unchanged (the
-  CONNECTED-document 3003 guard still lives in the tools, not here).
-- **Path B — in-memory base64 (open document, OASP 0.3.0):** the Server never
-  touches disk; it exchanges single-slide ``.pptx`` packages as base64 over the
-  wire with the Add-In (which exports the live slide via
-  ``Slide.exportAsBase64`` and re-inserts via ``insertSlidesFromBase64``). The
-  engine offers two in-memory shapes:
+Single execution path: in-memory base64 (open document, OASP 0.3.0)
+===================================================================
+The Server never touches disk; it exchanges single-slide ``.pptx`` packages as
+base64 over the wire with the Add-In (which exports the live slide via
+``Slide.exportAsBase64`` and re-inserts via ``insertSlidesFromBase64``). The
+engine offers two in-memory shapes:
 
-  * *generate standalone single page* — build a fresh 1-slide deck containing the
-    chart and return it as base64 (used by "insert → new page"; needs no input
-    package);
-  * *modify a single page* — load a base64 single-slide package, locate/add/edit
-    the chart, return the package back as base64 (used by get / update /
-    insert-into-existing-page).
+* *generate standalone single page* — build a fresh 1-slide deck containing the
+  chart and return it as base64 (used by "insert → new page"; needs no input
+  package);
+* *modify a single page* — load a base64 single-slide package, locate/add/edit
+  the chart, return the package back as base64 (used by get / update /
+  insert-into-existing-page).
 
-  All chart OOXML logic stays here in python-pptx; the Add-In only carries
-  generic, chart-agnostic primitives. Routing between Path A and Path B is the
-  responsibility of the chart tools (#15), not this module.
+All chart OOXML logic stays here in python-pptx; the Add-In only carries generic,
+chart-agnostic primitives. The chart tools (#15) drive this path only when the
+target document is CONNECTED; a closed document is refused with guidance to the
+authoring pipeline (``office_run_script`` + python-pptx). The former on-disk
+"Path A" was removed in F1 (#68) — offline chart authoring is served by the
+scripting runtime, not by this engine writing ``.pptx`` files directly.
 
-Operational constraints (Path A only; mirrored from the OASP events-ppt admonition):
+Operational constraints:
 
-- The Add-In must ``save()`` the document before calling — unsaved client edits
-  will be overwritten when this engine rewrites the .pptx on disk.
 - Concurrent chart calls on the same document must be serialized (see
   ``document_lock.DocumentLockManager``); two simultaneous writes corrupt the
   OOXML package.
-- Latency is dominated by disk I/O and python-pptx parsing — typically >1s on
-  multi-MB decks.
+- Latency is dominated by python-pptx parsing of the exported slide package.
 
 Element identity
 ================
@@ -61,10 +57,8 @@ import base64
 import binascii
 import io
 import math
-import urllib.parse
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from pptx import Presentation
@@ -137,30 +131,6 @@ def _xl_chart_type(chart_type: str) -> XL_CHART_TYPE:
             code=ErrorCode.INVALID_PARAM,
             message=f"Unsupported chartType: {chart_type!r}",
         ) from exc
-
-
-# ---------------------------------------------------------------------------
-# URI ↔ filesystem path
-# ---------------------------------------------------------------------------
-
-
-def _uri_to_path(document_uri: str) -> Path:
-    """Convert a ``file://`` URI to a local Path. Raises 3001 if invalid."""
-    parsed = urllib.parse.urlparse(document_uri)
-    if parsed.scheme != "file":
-        raise ChartEngineError(
-            code=ErrorCode.DOCUMENT_NOT_FOUND,
-            message=f"Only file:// URIs are supported, got: {document_uri!r}",
-        )
-    # urllib gives us an unquoted path with a leading slash even on macOS/Linux.
-    raw = urllib.parse.unquote(parsed.path)
-    path = Path(raw)
-    if not path.exists():
-        raise ChartEngineError(
-            code=ErrorCode.DOCUMENT_NOT_FOUND,
-            message=f"Document not found: {path}",
-        )
-    return path
 
 
 # ---------------------------------------------------------------------------
@@ -454,7 +424,7 @@ def _is_categorical(chart_type: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# OOXML core — operate on an already-loaded ``Presentation`` (Path A + Path B share these)
+# OOXML core — operate on an already-loaded ``Presentation`` (shared by every entry point)
 # ---------------------------------------------------------------------------
 
 
@@ -765,7 +735,7 @@ def _modify_chart_in_prs(
 
 
 # ---------------------------------------------------------------------------
-# base64 single-slide package helpers (Path B)
+# base64 single-slide package helpers (client round-trip)
 # ---------------------------------------------------------------------------
 
 
@@ -804,61 +774,7 @@ def _first_slide(prs: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Path A — on-disk blocking implementations
-# ---------------------------------------------------------------------------
-
-
-def _insert_chart_blocking(
-    document_path: Path,
-    chart_data: CategoricalChartData | ScatterChartData,
-    options: ChartInsertOptions | None,
-) -> dict[str, Any]:
-    prs = Presentation(str(document_path))
-
-    slide_index_target = options.slide_index if options and options.slide_index is not None else None
-    if slide_index_target is None:
-        slide_index_target = 0
-    if slide_index_target < 0 or slide_index_target >= len(prs.slides):
-        raise ChartEngineError(
-            code=ErrorCode.INVALID_PARAM,
-            message=(f"slideIndex {slide_index_target} out of range [0, {len(prs.slides) - 1}]"),
-        )
-    slide = prs.slides[slide_index_target]
-
-    chart_shape, element_id = _add_chart_to_slide(prs, slide, chart_data, options)
-    prs.save(str(document_path))
-    return _insert_result(element_id, slide_index_target, chart_data, chart_shape)
-
-
-def _get_chart_blocking(document_path: Path, element_id: str, hint_index: int | None) -> dict[str, Any]:
-    prs = Presentation(str(document_path))
-    _slide, shape, slide_idx = _find_chart(prs, element_id, hint_index)
-    return {
-        "elementId": element_id,
-        "slideIndex": slide_idx,
-        "chart": _extract_chart_data(shape.chart),
-        **_geometry_dict(shape),
-    }
-
-
-def _update_chart_blocking(
-    document_path: Path,
-    element_id: str,
-    update: CategoricalChartUpdate | ScatterChartUpdate,
-) -> dict[str, Any]:
-    prs = Presentation(str(document_path))
-    slide, shape, _slide_idx = _find_chart(prs, element_id, None)
-    returned_id, updated_fields = _modify_chart_in_prs(slide, shape, element_id, update)
-    prs.save(str(document_path))
-    return {
-        "elementId": returned_id,
-        "chartType": update.chart_type,
-        "updatedFields": updated_fields,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Path B — in-memory base64 blocking implementations
+# In-memory base64 blocking implementations (open document, OASP 0.3.0)
 # ---------------------------------------------------------------------------
 
 
@@ -919,42 +835,7 @@ def _update_chart_in_slide_b64_blocking(
 
 
 # ---------------------------------------------------------------------------
-# Async wrappers — Path A (on-disk; offload blocking I/O to a worker thread)
-# ---------------------------------------------------------------------------
-
-
-async def insert_chart(
-    document_uri: str,
-    chart_data: CategoricalChartData | ScatterChartData,
-    options: ChartInsertOptions | None,
-) -> dict[str, Any]:
-    """Insert a new chart into the .pptx at ``document_uri``.
-
-    Raises ``ChartEngineError`` (carrying an OASP code) on validation / IO failure.
-    """
-    path = _uri_to_path(document_uri)
-    _validate_chart_data(chart_data)
-    return await asyncio.to_thread(_insert_chart_blocking, path, chart_data, options)
-
-
-async def get_chart(document_uri: str, element_id: str, slide_index: int | None = None) -> dict[str, Any]:
-    """Read an existing chart's data into the OASP ``ChartData`` wire shape."""
-    path = _uri_to_path(document_uri)
-    return await asyncio.to_thread(_get_chart_blocking, path, element_id, slide_index)
-
-
-async def update_chart(
-    document_uri: str,
-    element_id: str,
-    update: CategoricalChartUpdate | ScatterChartUpdate,
-) -> dict[str, Any]:
-    """Apply a partial update to an existing chart."""
-    path = _uri_to_path(document_uri)
-    return await asyncio.to_thread(_update_chart_blocking, path, element_id, update)
-
-
-# ---------------------------------------------------------------------------
-# Async wrappers — Path B (in-memory base64; no disk access)
+# Async wrappers — in-memory base64 (no disk access)
 # ---------------------------------------------------------------------------
 
 

--- a/office4ai/environment/workspace/services/chart_router.py
+++ b/office4ai/environment/workspace/services/chart_router.py
@@ -1,44 +1,34 @@
-"""Dual-path router for the OASP /ppt chart tools (#15, OASP 0.3.0).
+"""Client round-trip driver for the OASP /ppt chart tools (#15, OASP 0.3.0).
 
 The three chart tools (``ppt_insert_chart`` / ``ppt_get_chart`` /
-``ppt_update_chart``) pick one of two execution paths per call, by document
-connection status:
+``ppt_update_chart``) operate on a single execution path: the CONNECTED client
+round-trip. The Server drives the Add-In's *generic*, chart-agnostic OOXML
+carrier events (``ppt:get:slideOoxml`` / ``ppt:insert:slidesOoxml``, published
+normative in OASP 0.3.0) and performs *all* chart OOXML work in-memory via
+``chart_engine``'s base64 helpers. The Add-In only exports / inserts / replaces /
+repositions slides — it never touches chart semantics.
 
-- **Path A — on-disk (DISCONNECTED):** delegate to ``chart_engine``'s on-disk
-  helpers (the original 0.2.0 behaviour, unchanged).
-- **Path B — client round-trip (CONNECTED):** the Server drives the Add-In's
-  *generic*, chart-agnostic OOXML carrier events
-  (``ppt:get:slideOoxml`` / ``ppt:insert:slidesOoxml``, published normative in
-  OASP 0.3.0) and performs *all* chart OOXML work in-memory via ``chart_engine``'s
-  base64 helpers. The Add-In only exports / inserts / replaces / repositions
-  slides — it never touches chart semantics.
-
-Why route instead of the old up-front 3003 guard
-=================================================
-0.2.0 refused chart *writes* up-front when the document was open in PowerPoint
-(``DocumentStatus.CONNECTED``) because a Server on-disk write would be silently
-overwritten by PowerPoint's next ``save()``. Path B removes that hazard: when the
-document is open we mutate the *live* slide through the Add-In, so the open
-document is no longer a reason to refuse — it is the reason to route to path B.
+Connected-only (Path A removed in F1 #68)
+=========================================
+The former on-disk "Path A" (a Server-side python-pptx read/write of a closed
+``.pptx``) was removed once the authoring pipeline (``office_run_script`` +
+python-pptx) took over offline chart work. The tools now refuse a DISCONNECTED
+target with :data:`OFFLINE_MESSAGE`, steering the caller to that pipeline rather
+than writing the file directly. This keeps chart behaviour aligned with the W4a
+binary tool-convergence model (#63): a chart tool is only exposed while a /ppt
+Add-In connection exists, and only truly operates on the document that is open.
 
 Reactive degradation
 =====================
 office-editor4ai's Add-In handlers for the carrier events ship in a later
-milestone (#16). Until they do, a CONNECTED path-B attempt fails — the Add-In
+milestone (#16). Until they do, a CONNECTED round-trip attempt fails — the Add-In
 has no handler (Socket.IO ``.call()`` times out), acks ``3016 API_NOT_SUPPORTED``,
 or the platform lacks the required Office.js requirement set. We *react* to that
-failure rather than gate on a capability flag up-front:
-
-- **insert / update** → raise :class:`PathBUnavailable`; the tool surfaces the
-  explicit "close the document, then retry" guidance (:data:`DEGRADE_MESSAGE_WRITE`)
-  — the same advice the 0.2.0 up-front 3003 guard gave, but now *after* attempting
-  path B rather than instead of it (the flipped guard semantics).
-- **get** → the tool falls back to path A (a disk read has no overwrite hazard;
-  at worst it returns stale data, exactly the 0.2.0 read-while-connected behaviour).
-
-When the Add-In ships, the same path-B code starts succeeding with no Server
-change. A genuine business error from a *working* Add-In (e.g. 3010 chart not
-found) is surfaced as :class:`ChartEngineError`, never silently degraded.
+failure with :data:`DEGRADE_MESSAGE` (close the document and edit the chart
+offline via the authoring pipeline) rather than gating on a capability flag
+up-front. When the Add-In ships, the same round-trip code starts succeeding with
+no Server change. A genuine business error from a *working* Add-In (e.g. 3010
+chart not found) is surfaced as :class:`ChartEngineError`, never degraded.
 """
 
 from __future__ import annotations
@@ -72,16 +62,36 @@ _KEEP_SOURCE_FORMATTING = "keepSourceFormatting"
 #: Error codes that mean "path B is not usable on this client right now" (degrade).
 _DEGRADE_CODES = frozenset({ErrorCode.API_NOT_SUPPORTED})  # "3016"
 
-#: Surfaced when a chart write is routed to path B but path B is unavailable
+#: Refused when a chart tool targets a DISCONNECTED document: there is no live
+#: round-trip to drive and the Server no longer edits closed files on disk (Path A
+#: removed in F1 #68). The "3003" prefix keeps the familiar code; the guidance
+#: steers offline chart work to the authoring pipeline.
+OFFLINE_MESSAGE = (
+    "3003: Target document is not open in PowerPoint via the Add-In, so live chart "
+    "operations are unavailable. For chart work on a closed .pptx, use the authoring "
+    "pipeline instead — call office_run_script with a python-pptx script (see the "
+    "create-office-file / edit-office-file SKILL)."
+)
+
+#: Surfaced when the document is open but the client round-trip is not usable yet
 #: (Add-In handler pending / unsupported requirement set / timeout). Keeps the
-#: "3003" prefix so the LLM still sees the familiar "close the document" code.
-DEGRADE_MESSAGE_WRITE = (
-    "3003: Document is open in PowerPoint via the Add-In, but the client round-trip "
+#: "3003" prefix; steers offline chart work to the authoring pipeline (there is no
+#: longer an on-disk fallback — Path A was removed in F1 #68).
+DEGRADE_MESSAGE = (
+    "3003: The document is open in PowerPoint via the Add-In, but the client round-trip "
     "path (OASP ppt:get:slideOoxml / ppt:insert:slidesOoxml) is not available yet "
     "(Add-In handler pending or required Office.js requirement set unsupported). "
-    "Ask the user to close the document in PowerPoint, then retry — the Server will "
-    "apply the change on disk. This restriction lifts automatically once the Add-In "
-    "ships the OOXML carrier events."
+    "To work on the chart offline, ask the user to close the document, then use the "
+    "authoring pipeline (office_run_script + python-pptx). This restriction lifts "
+    "automatically once the Add-In ships the OOXML carrier events."
+)
+
+#: Surfaced when a chart operation on an OPEN document lacks the slideIndex needed
+#: to export that live slide (both get and update require it for the round-trip).
+LIVE_NEEDS_SLIDE_INDEX = (
+    "3003: slideIndex (0-based) is required to operate on a chart while the document is "
+    "open in PowerPoint — the live round-trip must export that specific slide. Supply the "
+    "slide's index and retry."
 )
 
 
@@ -160,16 +170,15 @@ async def insert_chart_path_b(
     """CONNECTED insert: export the live target slide, add the chart in-memory,
     then re-insert it in place (replace the old slide, restore its position).
 
-    Mirrors path A semantics (the chart lands on the existing target slide, keeping
-    that slide's other content), but operates on the live unsaved document.
+    The chart lands on the existing target slide (default slide 0), keeping that
+    slide's other content, and operates on the live unsaved document.
 
     Deliberately does NOT use ``chart_engine.generate_chart_slide_base64`` (the
-    "standalone new page" mode): path A (``_insert_chart_blocking``) has no
-    new-page semantics either — it rejects an out-of-range ``slideIndex`` — so this
-    mirror keeps insert consistent across both paths. The generate-a-new-page mode
-    is reserved for a future explicit "append slide" capability (it needs an input
-    signal to request it, and on an open document a deck-length query to detect the
-    append case), wired alongside the #16 E2E work, not inferred here.
+    "standalone new page" mode): insert always targets an existing slide here. The
+    generate-a-new-page mode is reserved for a future explicit "append slide"
+    capability (it needs an input signal to request it, and on an open document a
+    deck-length query to detect the append case), wired alongside the #16 E2E work,
+    not inferred here.
     """
     slide_index = options.slide_index if options is not None and options.slide_index is not None else 0
 

--- a/office4ai/environment/workspace/services/document_lock.py
+++ b/office4ai/environment/workspace/services/document_lock.py
@@ -2,8 +2,8 @@
 Document-level async lock manager.
 
 Used by the OOXML chart engine to serialize concurrent writes against the same
-.pptx file. The OASP /ppt chart events open and rewrite OOXML directly on disk;
-two concurrent writes would corrupt the package.
+document. The OASP /ppt chart events drive a base64 slide round-trip (export →
+mutate in-memory → re-insert); two concurrent writes would corrupt the package.
 
 Usage::
 

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from office4ai.a2c_smcp.resources.per_file_window import affected_window_uris
 from office4ai.a2c_smcp.tools.ppt import (
     PptAddSlideTool,
     PptDeleteElementTool,
@@ -1023,8 +1022,12 @@ def _extract_types_from_schema(schema: dict) -> set[str]:
 # exercised end-to-end.
 
 
-class TestChartToolExecute:
-    """End-to-end execute() tests for the 3 chart tools (real .pptx fixture)."""
+class TestChartToolConnectedOnly:
+    """execute() tests for the 3 chart tools after Path A removal (#68).
+
+    A DISCONNECTED target is refused with authoring-pipeline guidance; the live
+    (CONNECTED) round-trip is exercised in TestChartToolDualPathRouting below.
+    """
 
     @pytest.fixture
     def deck_uri(self, tmp_path):
@@ -1038,20 +1041,22 @@ class TestChartToolExecute:
         return path.as_uri()
 
     @pytest.fixture
-    def workspace_with_notify(self):
-        # Default: no Add-In holding the file → chart writes are allowed.
-        # Tests that exercise the CONNECTED-reject path override this per-test.
+    def disconnected_ws(self):
+        # No Add-In holding the file → chart tools refuse and steer to authoring (#68).
         from office4ai.environment.workspace.base import DocumentStatus
 
         ws = MagicMock()
         ws.notify_resource_updated = MagicMock()
         ws.update_last_activity = MagicMock()
+        ws.emit_to_document = AsyncMock()
         ws.get_document_status = MagicMock(return_value=DocumentStatus.DISCONNECTED)
         return ws
 
     @pytest.mark.asyncio
-    async def test_insert_chart_returns_element_id_and_fires_notify(self, workspace_with_notify, deck_uri):
-        tool = PptInsertChartTool(workspace_with_notify)
+    async def test_insert_offline_refused(self, disconnected_ws, deck_uri):
+        from office4ai.environment.workspace.services import chart_router
+
+        tool = PptInsertChartTool(disconnected_ws)
         result = await tool.execute(
             {
                 "document_uri": deck_uri,
@@ -1059,55 +1064,53 @@ class TestChartToolExecute:
                     "chartType": "ColumnClustered",
                     "categories": ["A", "B"],
                     "series": [{"name": "x", "values": [1, 2]}],
-                    "title": "T",
                 },
                 "options": {"slideIndex": 0},
             }
         )
-        assert result["success"] is True
-        assert result["data"]["elementId"].startswith("oasp-chart-")
-        assert result["data"]["requiresReload"] is True
-        # Server-OOXML mutations must trigger MCP resource_updated notifications
-        # (W4b-1: the file's per-file window; not the root index — the connected-file set is unchanged).
-        workspace_with_notify.notify_resource_updated.assert_called_once_with(affected_window_uris("/ppt", deck_uri))
-        workspace_with_notify.update_last_activity.assert_called_once()
+        assert result["success"] is False
+        # Closed document → refuse and steer to the authoring pipeline (Path A removed, #68).
+        assert result["error"] == chart_router.OFFLINE_MESSAGE
+        assert "office_run_script" in result["error"]
+        disconnected_ws.emit_to_document.assert_not_awaited()
+        disconnected_ws.notify_resource_updated.assert_not_called()
+        disconnected_ws.update_last_activity.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_insert_scatter_chart(self, workspace_with_notify, deck_uri):
-        tool = PptInsertChartTool(workspace_with_notify)
+    async def test_update_offline_refused(self, disconnected_ws, deck_uri):
+        from office4ai.environment.workspace.services import chart_router
+
+        tool = PptUpdateChartTool(disconnected_ws)
         result = await tool.execute(
             {
                 "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "Scatter",
-                    "series": [{"name": "ads", "points": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]}],
-                },
-            }
-        )
-        assert result["success"] is True
-        assert result["data"]["chartType"] == "Scatter"
-
-    @pytest.mark.asyncio
-    async def test_insert_dimension_mismatch_returns_3015(self, workspace_with_notify, deck_uri):
-        tool = PptInsertChartTool(workspace_with_notify)
-        result = await tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "Pie",
-                    "categories": ["A", "B", "C"],
-                    "series": [{"name": "x", "values": [1, 2]}],  # 2 != 3
-                },
+                "elementId": "oasp-chart-abc",
+                "slideIndex": 0,
+                "chart": {"chartType": "Line", "title": "x"},
             }
         )
         assert result["success"] is False
-        assert "3015" in result["error"]
-        # Failed insert should NOT fire reload notification.
-        workspace_with_notify.notify_resource_updated.assert_not_called()
+        assert result["error"] == chart_router.OFFLINE_MESSAGE
+        disconnected_ws.emit_to_document.assert_not_awaited()
+        disconnected_ws.notify_resource_updated.assert_not_called()
+        disconnected_ws.update_last_activity.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_insert_invalid_chart_type_rejected_at_validation(self, workspace_with_notify, deck_uri):
-        tool = PptInsertChartTool(workspace_with_notify)
+    async def test_get_offline_refused(self, disconnected_ws, deck_uri):
+        from office4ai.environment.workspace.services import chart_router
+
+        tool = PptGetChartTool(disconnected_ws)
+        result = await tool.execute({"document_uri": deck_uri, "elementId": "oasp-chart-abc", "slideIndex": 0})
+        assert result["success"] is False
+        assert result["error"] == chart_router.OFFLINE_MESSAGE
+        disconnected_ws.emit_to_document.assert_not_awaited()
+        disconnected_ws.update_last_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_insert_invalid_chart_type_rejected_at_validation(self, disconnected_ws, deck_uri):
+        # Discriminator validation happens before the connection check, so a bogus
+        # chartType is rejected up-front regardless of connection status.
+        tool = PptInsertChartTool(disconnected_ws)
         result = await tool.execute(
             {
                 "document_uri": deck_uri,
@@ -1117,191 +1120,16 @@ class TestChartToolExecute:
         assert result["success"] is False
         assert "error" in result
 
-    @pytest.mark.asyncio
-    async def test_get_chart_returns_data_without_notify(self, workspace_with_notify, deck_uri):
-        # Insert first to obtain an elementId.
-        i_tool = PptInsertChartTool(workspace_with_notify)
-        ins = await i_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "Line",
-                    "categories": ["A", "B"],
-                    "series": [{"name": "x", "values": [1, 2]}],
-                    "title": "Trend",
-                },
-            }
-        )
-        eid = ins["data"]["elementId"]
-        workspace_with_notify.notify_resource_updated.reset_mock()
-
-        g_tool = PptGetChartTool(workspace_with_notify)
-        result = await g_tool.execute({"document_uri": deck_uri, "elementId": eid})
-        assert result["success"] is True
-        assert result["data"]["chart"]["chartType"] == "Line"
-        assert result["data"]["chart"]["title"] == "Trend"
-        # Read-only — must not fire reload notification.
-        workspace_with_notify.notify_resource_updated.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_get_chart_int_element_id_coerced(self, workspace_with_notify, deck_uri):
-        # Insert and grab the numeric portion.
-        i_tool = PptInsertChartTool(workspace_with_notify)
-        ins = await i_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "Pie",
-                    "categories": ["A"],
-                    "series": [{"name": "x", "values": [1]}],
-                },
-            }
-        )
-        eid = ins["data"]["elementId"]  # "chart-N"
-        # Tool input model coerces int elementId — but here we test str works (default path).
-        g_tool = PptGetChartTool(workspace_with_notify)
-        result = await g_tool.execute({"document_uri": deck_uri, "elementId": eid})
-        assert result["success"] is True
-
-    @pytest.mark.asyncio
-    async def test_get_chart_unknown_element_returns_3010(self, workspace_with_notify, deck_uri):
-        g_tool = PptGetChartTool(workspace_with_notify)
-        result = await g_tool.execute({"document_uri": deck_uri, "elementId": "chart-99999"})
-        assert result["success"] is False
-        assert "3010" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_update_chart_title_only(self, workspace_with_notify, deck_uri):
-        i_tool = PptInsertChartTool(workspace_with_notify)
-        ins = await i_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "BarClustered",
-                    "categories": ["A", "B"],
-                    "series": [{"name": "x", "values": [1, 2]}],
-                    "title": "Old",
-                },
-            }
-        )
-        eid = ins["data"]["elementId"]
-        workspace_with_notify.notify_resource_updated.reset_mock()
-
-        u_tool = PptUpdateChartTool(workspace_with_notify)
-        result = await u_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "elementId": eid,
-                "chart": {"chartType": "BarClustered", "title": "New"},
-            }
-        )
-        assert result["success"] is True
-        assert "title" in result["data"]["updatedFields"]
-        assert result["data"]["requiresReload"] is True
-        workspace_with_notify.notify_resource_updated.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_update_chart_dimension_mismatch_returns_3015(self, workspace_with_notify, deck_uri):
-        i_tool = PptInsertChartTool(workspace_with_notify)
-        ins = await i_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "ColumnClustered",
-                    "categories": ["A", "B"],
-                    "series": [{"name": "x", "values": [1, 2]}],
-                },
-            }
-        )
-        eid = ins["data"]["elementId"]
-
-        u_tool = PptUpdateChartTool(workspace_with_notify)
-        result = await u_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "elementId": eid,
-                "chart": {
-                    "chartType": "ColumnClustered",
-                    "categories": ["X", "Y", "Z"],
-                    "series": [{"name": "t", "values": [10, 20]}],  # 2 != 3
-                },
-            }
-        )
-        assert result["success"] is False
-        assert "3015" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_update_cross_variant_returns_new_element_id(self, workspace_with_notify, deck_uri):
-        i_tool = PptInsertChartTool(workspace_with_notify)
-        ins = await i_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "chart": {
-                    "chartType": "ColumnClustered",
-                    "categories": ["A", "B"],
-                    "series": [{"name": "x", "values": [1, 2]}],
-                },
-            }
-        )
-        old_eid = ins["data"]["elementId"]
-
-        u_tool = PptUpdateChartTool(workspace_with_notify)
-        result = await u_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "elementId": old_eid,
-                "chart": {
-                    "chartType": "Scatter",
-                    "series": [{"name": "p", "points": [{"x": 1, "y": 2}, {"x": 3, "y": 4}]}],
-                },
-            }
-        )
-        assert result["success"] is True
-        assert result["data"]["chartType"] == "Scatter"
-        assert "chartType" in result["data"]["updatedFields"]
-        # Recreate preserves the opaque id (written to cNvPr/@name); OASP returns the latest elementId.
-        new_eid = result["data"]["elementId"]
-        assert new_eid.startswith("oasp-chart-")
-        assert new_eid == old_eid
-
-    @pytest.mark.asyncio
-    async def test_update_unknown_element_returns_3010(self, workspace_with_notify, deck_uri):
-        u_tool = PptUpdateChartTool(workspace_with_notify)
-        result = await u_tool.execute(
-            {
-                "document_uri": deck_uri,
-                "elementId": "chart-99999",
-                "chart": {"chartType": "ColumnClustered", "title": "x"},
-            }
-        )
-        assert result["success"] is False
-        assert "3010" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_insert_missing_document_returns_3001(self, workspace_with_notify):
-        tool = PptInsertChartTool(workspace_with_notify)
-        result = await tool.execute(
-            {
-                "document_uri": "file:///does/not/exist.pptx",
-                "chart": {
-                    "chartType": "Line",
-                    "categories": ["A"],
-                    "series": [{"name": "x", "values": [1]}],
-                },
-            }
-        )
-        assert result["success"] is False
-        assert "3001" in result["error"]
-
 
 # ============================================================================
-# Dual-path routing (#15, OASP 0.3.0) — route by DocumentStatus
+# Connected-only routing (#15/#68, OASP 0.3.0) — CONNECTED drives the live round-trip
 # ============================================================================
-# CONNECTED → path B (client round-trip: ppt:get:slideOoxml / ppt:insert:slidesOoxml,
-# all chart OOXML built Server-side). DISCONNECTED → path A (on-disk python-pptx).
-# Because the Add-In carrier-event handlers ship later (#16), a CONNECTED path-B
-# attempt currently fails (timeout / 3016) → reactive degradation: writes surface
-# the flipped 3003 guidance, reads fall back to the on-disk read.
+# CONNECTED → live client round-trip (ppt:get:slideOoxml / ppt:insert:slidesOoxml,
+# all chart OOXML built Server-side). DISCONNECTED → refused (OFFLINE_MESSAGE): the
+# former on-disk Path A was removed in #68; offline chart work goes to the authoring
+# pipeline. Because the Add-In carrier-event handlers ship later (#16), a CONNECTED
+# round-trip currently fails (timeout / 3016) → reactive degradation to DEGRADE_MESSAGE
+# (close the document and use office_run_script).
 
 
 def _disconnected_ws():
@@ -1365,22 +1193,9 @@ def _emit_returns_3016(document_uri, event, data):
     return {"success": False, "error": {"code": "3016", "message": "PowerPointApi 1.8 unavailable"}}
 
 
-async def _insert_on_disk(deck_uri, slide_index=0, chart_type="Line"):
-    """Insert a chart via the on-disk (DISCONNECTED) path; return its elementId."""
-    ins = await PptInsertChartTool(_disconnected_ws()).execute(
-        {
-            "document_uri": deck_uri,
-            "chart": {"chartType": chart_type, "categories": ["A", "B"], "series": [{"name": "x", "values": [1, 2]}]},
-            "options": {"slideIndex": slide_index},
-        }
-    )
-    assert ins["success"], ins
-    return ins["data"]["elementId"]
-
-
 class TestChartToolDualPathRouting:
-    """#15: CONNECTED → client round-trip (path B); DISCONNECTED → on-disk (path A);
-    path B failure → reactive degradation."""
+    """#15/#68: CONNECTED → live client round-trip; DISCONNECTED → refused (Path A removed);
+    live round-trip failure → reactive degradation to offline-authoring guidance."""
 
     @pytest.fixture
     def deck_uri(self, tmp_path):
@@ -1393,10 +1208,12 @@ class TestChartToolDualPathRouting:
         prs.save(str(path))
         return path.as_uri()
 
-    # -- DISCONNECTED → on-disk, no client round-trip ----------------------------
+    # -- DISCONNECTED → refused up-front (Path A removed, #68) --------------------
 
     @pytest.mark.asyncio
-    async def test_disconnected_insert_uses_disk_and_does_not_emit(self, deck_uri):
+    async def test_disconnected_insert_refused_and_does_not_emit(self, deck_uri):
+        from office4ai.environment.workspace.services import chart_router
+
         ws = _disconnected_ws()
         ws.emit_to_document = AsyncMock()
         result = await PptInsertChartTool(ws).execute(
@@ -1406,10 +1223,10 @@ class TestChartToolDualPathRouting:
                 "options": {"slideIndex": 0},
             }
         )
-        assert result["success"] is True
-        # On-disk write → the deck must be reopened to render.
-        assert result["data"]["requiresReload"] is True
+        assert result["success"] is False
+        assert result["error"] == chart_router.OFFLINE_MESSAGE
         ws.emit_to_document.assert_not_awaited()
+        ws.notify_resource_updated.assert_not_called()
 
     # -- CONNECTED → path B happy path (mocked carrier events) -------------------
 
@@ -1439,7 +1256,10 @@ class TestChartToolDualPathRouting:
         assert apply_payload["formatting"] == "keepSourceFormatting"
         assert apply_payload["replaceSlideId"] == "sid-export"
         assert apply_payload["finalSlideIndex"] == 0
-        ws.notify_resource_updated.assert_called_once()
+        from office4ai.a2c_smcp.resources.per_file_window import affected_window_uris
+
+        # Notify the RIGHT per-file window (the file just written), not merely "some" notify.
+        ws.notify_resource_updated.assert_called_once_with(affected_window_uris("/ppt", deck_uri))
 
     @pytest.mark.asyncio
     async def test_get_routes_to_path_b_when_connected_with_hint(self, deck_uri):
@@ -1500,7 +1320,44 @@ class TestChartToolDualPathRouting:
         assert events == ["ppt:get:slideOoxml", "ppt:insert:slidesOoxml"]
         ws.notify_resource_updated.assert_called_once()
 
-    # -- Reactive degradation: writes → 3003, reads → on-disk fallback -----------
+    # -- CONNECTED → engine business errors surfaced verbatim (not degraded) ------
+
+    @pytest.mark.asyncio
+    async def test_insert_dimension_mismatch_surfaced_as_3015(self, deck_uri):
+        # Bad dimensions are caught Server-side (after the export round-trip) and surfaced verbatim.
+        ws = _connected_ws(_make_path_b_emit(_blank_slide_b64()))
+        result = await PptInsertChartTool(ws).execute(
+            {
+                "document_uri": deck_uri,
+                "chart": {
+                    "chartType": "Pie",
+                    "categories": ["A", "B", "C"],
+                    "series": [{"name": "x", "values": [1, 2]}],
+                },
+                "options": {"slideIndex": 0},
+            }
+        )
+        assert result["success"] is False
+        assert "3015" in result["error"]
+        ws.notify_resource_updated.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_element_surfaced_as_3010(self, deck_uri):
+        # The exported slide carries no chart at this id → 3010 from the engine, surfaced verbatim.
+        ws = _connected_ws(_make_path_b_emit(_blank_slide_b64()))
+        result = await PptUpdateChartTool(ws).execute(
+            {
+                "document_uri": deck_uri,
+                "elementId": "oasp-chart-missing",
+                "slideIndex": 0,
+                "chart": {"chartType": "Line", "title": "x"},
+            }
+        )
+        assert result["success"] is False
+        assert "3010" in result["error"]
+        ws.notify_resource_updated.assert_not_called()
+
+    # -- Reactive degradation: live round-trip unavailable → 3003 offline guidance ----
 
     @pytest.mark.asyncio
     async def test_insert_degrades_when_path_b_times_out(self, deck_uri):
@@ -1552,8 +1409,10 @@ class TestChartToolDualPathRouting:
         assert "3003" not in result["error"]
 
     @pytest.mark.asyncio
-    async def test_update_degrades_when_connected_without_slide_hint(self, deck_uri):
-        ws = _connected_ws()  # emit must never be awaited — degrade is up-front
+    async def test_update_refused_when_connected_without_slide_hint(self, deck_uri):
+        from office4ai.environment.workspace.services import chart_router
+
+        ws = _connected_ws()  # emit must never be awaited — refuse is up-front
         result = await PptUpdateChartTool(ws).execute(
             {
                 "document_uri": deck_uri,
@@ -1562,7 +1421,9 @@ class TestChartToolDualPathRouting:
             }
         )
         assert result["success"] is False
-        assert "3003" in result["error"]
+        # Exact message: all three refuse strings share the "3003:" prefix, so a substring
+        # check cannot prove this is the *slideIndex-missing* case rather than offline/degrade.
+        assert result["error"] == chart_router.LIVE_NEEDS_SLIDE_INDEX
         ws.emit_to_document.assert_not_awaited()
         ws.notify_resource_updated.assert_not_called()
 
@@ -1582,21 +1443,25 @@ class TestChartToolDualPathRouting:
         ws.notify_resource_updated.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_degrades_to_disk_when_path_b_times_out(self, deck_uri):
-        eid = await _insert_on_disk(deck_uri, slide_index=0, chart_type="Line")
+    async def test_get_degrades_when_path_b_times_out(self, deck_uri):
+        # No on-disk fallback anymore (#68): a live read whose round-trip times out is refused.
         ws = _connected_ws(TimeoutError("no ack from Add-In"))
-        result = await PptGetChartTool(ws).execute({"document_uri": deck_uri, "elementId": eid, "slideIndex": 0})
-        # Read-only degradation falls back to the on-disk read — still succeeds.
-        assert result["success"] is True
-        assert result["data"]["chart"]["chartType"] == "Line"
+        result = await PptGetChartTool(ws).execute(
+            {"document_uri": deck_uri, "elementId": "oasp-chart-abc", "slideIndex": 0}
+        )
+        assert result["success"] is False
+        assert "3003" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_get_uses_disk_when_connected_without_hint(self, deck_uri):
-        eid = await _insert_on_disk(deck_uri, slide_index=0, chart_type="Pie")
-        ws = _connected_ws()  # no slideIndex → on-disk read, no round-trip
-        result = await PptGetChartTool(ws).execute({"document_uri": deck_uri, "elementId": eid})
-        assert result["success"] is True
-        assert result["data"]["chart"]["chartType"] == "Pie"
+    async def test_get_refused_when_connected_without_hint(self, deck_uri):
+        # A live read needs slideIndex to export the slide; without it the tool refuses up-front (#68).
+        from office4ai.environment.workspace.services import chart_router
+
+        ws = _connected_ws()  # emit must never be awaited
+        result = await PptGetChartTool(ws).execute({"document_uri": deck_uri, "elementId": "oasp-chart-abc"})
+        assert result["success"] is False
+        assert result["error"] == chart_router.LIVE_NEEDS_SLIDE_INDEX
+        ws.emit_to_document.assert_not_awaited()
         ws.emit_to_document.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1642,20 +1507,19 @@ class TestChartToolDualPathRouting:
         assert disk_path.read_bytes() == before
 
     @pytest.mark.asyncio
-    async def test_get_path_b_business_error_surfaced_not_disk_fallback(self, deck_uri):
+    async def test_get_path_b_business_error_surfaced(self, deck_uri):
         # A working Add-In returning a genuine business error (3010) on export must be
-        # SURFACED, not silently swallowed into a stale on-disk read. Seed the disk WITH a
-        # chart at this elementId so a (wrong) silent fallback would *succeed* — the test
-        # then proves the tool fails with 3010 instead.
-        eid = await _insert_on_disk(deck_uri, slide_index=0, chart_type="Line")
-
+        # SURFACED as a real failure, never degraded to the 3003 offline guidance.
         def _emit(document_uri, event, data):
             return {"success": False, "error": {"code": "3010", "message": "chart not found on live slide"}}
 
         ws = _connected_ws(_emit)
-        result = await PptGetChartTool(ws).execute({"document_uri": deck_uri, "elementId": eid, "slideIndex": 0})
+        result = await PptGetChartTool(ws).execute(
+            {"document_uri": deck_uri, "elementId": "oasp-chart-abc", "slideIndex": 0}
+        )
         assert result["success"] is False
-        assert "3010" in result["error"]  # surfaced, NOT a stale disk success
+        assert "3010" in result["error"]
+        assert "3003" not in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_path_b_business_error_is_surfaced_not_degraded(self, deck_uri):

--- a/tests/unit_tests/office4ai/environment/workspace/services/test_chart_engine.py
+++ b/tests/unit_tests/office4ai/environment/workspace/services/test_chart_engine.py
@@ -1,11 +1,17 @@
-"""Unit tests for the OOXML chart engine (insert / get / update)."""
+"""Unit tests for the OOXML chart engine (in-memory base64 / Path B).
+
+The on-disk "Path A" surface (``insert_chart`` / ``get_chart`` / ``update_chart``
+taking a ``document_uri``) was removed in F1 (#68). These tests exercise the sole
+remaining engine surface: the in-memory base64 single-slide functions
+(``generate_chart_slide_base64`` / ``insert_chart_into_slide_base64`` /
+``get_chart_from_slide_base64`` / ``update_chart_in_slide_base64``).
+"""
 
 from __future__ import annotations
 
 import base64
 import io
 import math
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -25,127 +31,66 @@ from office4ai.environment.workspace.dtos.ppt import (
 from office4ai.environment.workspace.services import chart_engine
 from office4ai.environment.workspace.services.chart_engine import ChartEngineError
 
-
-@pytest.fixture
-def empty_pptx(tmp_path: Path) -> Path:
-    """A blank 2-slide deck."""
-    path = tmp_path / "deck.pptx"
-    prs = Presentation()
-    prs.slides.add_slide(prs.slide_layouts[5])
-    prs.slides.add_slide(prs.slide_layouts[5])
-    prs.save(str(path))
-    return path
+# NOTE: Two Path-A-only error paths were dropped when Path A was removed in #68:
+# 3001 DOCUMENT_NOT_FOUND (unknown document URI) and 4002 INVALID_PARAM (on-disk
+# multi-slide index out of range). Path A 已在 #68 删除，file-not-found /
+# on-disk 多页索引校验随之移除 — the base64 engine has no on-disk file to miss and
+# operates on a single slide, so neither check has a base64 equivalent.
 
 
 # ---------------------------------------------------------------------------
-# insert_chart
+# generate_chart_slide_base64 (new-page generation; was insert_chart Path A)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_insert_categorical_chart_returns_element_id(empty_pptx: Path) -> None:
-    chart = CategoricalChartData(
-        chartType="ColumnClustered",
-        categories=["Jan", "Feb", "Mar"],
-        series=[CategoricalSeries(name="Rev", values=[100, 200, 150])],
-        title="Q1",
-    )
-    result = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
-    assert result["elementId"].startswith("oasp-chart-")
-    assert result["chartType"] == "ColumnClustered"
-    assert result["seriesCount"] == 1
-    assert result["slideIndex"] == 0
-
-
-@pytest.mark.asyncio
-async def test_insert_uses_explicit_geometry(empty_pptx: Path) -> None:
+async def test_insert_uses_explicit_geometry() -> None:
     chart = CategoricalChartData(
         chartType="Pie",
         categories=["A", "B"],
         series=[CategoricalSeries(name="s", values=[1, 2])],
     )
-    result = await chart_engine.insert_chart(
-        empty_pptx.as_uri(),
+    result = await chart_engine.generate_chart_slide_base64(
         chart,
-        ChartInsertOptions(slideIndex=1, left=72, top=36, width=400, height=300),
+        ChartInsertOptions(left=72, top=36, width=400, height=300),
     )
     assert math.isclose(result["left"], 72, abs_tol=0.5)
     assert math.isclose(result["top"], 36, abs_tol=0.5)
     assert math.isclose(result["width"], 400, abs_tol=0.5)
     assert math.isclose(result["height"], 300, abs_tol=0.5)
-    assert result["slideIndex"] == 1
+    assert result["slideIndex"] == 0  # base64 packages are single-page
 
 
 @pytest.mark.asyncio
-async def test_insert_scatter_chart(empty_pptx: Path) -> None:
-    chart = ScatterChartData(
-        chartType="Scatter",
-        series=[
-            ScatterSeries(
-                name="ads",
-                points=[ScatterPoint(x=1, y=2), ScatterPoint(x=3, y=4)],
-            )
-        ],
-    )
-    result = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
-    assert result["chartType"] == "Scatter"
-    assert result["seriesCount"] == 1
-
-
-@pytest.mark.asyncio
-async def test_insert_categorical_dimension_mismatch_raises_3015(empty_pptx: Path) -> None:
+async def test_insert_categorical_dimension_mismatch_raises_3015() -> None:
     chart = CategoricalChartData(
         chartType="Pie",
         categories=["A", "B", "C"],
         series=[CategoricalSeries(name="x", values=[1, 2])],  # 2 != 3
     )
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None)
+        await chart_engine.generate_chart_slide_base64(chart, None)
     assert exc.value.code == ErrorCode.INVALID_CHART_DATA
 
 
 @pytest.mark.asyncio
-async def test_insert_scatter_non_finite_raises_3015(empty_pptx: Path) -> None:
+async def test_insert_scatter_non_finite_raises_3015() -> None:
     chart = ScatterChartData(
         chartType="Scatter",
         series=[ScatterSeries(name="s", points=[ScatterPoint(x=float("inf"), y=1)])],
     )
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None)
+        await chart_engine.generate_chart_slide_base64(chart, None)
     assert exc.value.code == ErrorCode.INVALID_CHART_DATA
 
 
-@pytest.mark.asyncio
-async def test_insert_unknown_document_uri_raises_3001() -> None:
-    chart = CategoricalChartData(
-        chartType="Line",
-        categories=["A"],
-        series=[CategoricalSeries(name="s", values=[1])],
-    )
-    with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.insert_chart("file:///nonexistent/missing.pptx", chart, None)
-    assert exc.value.code == ErrorCode.DOCUMENT_NOT_FOUND
-
-
-@pytest.mark.asyncio
-async def test_insert_slide_index_out_of_range_raises_4002(empty_pptx: Path) -> None:
-    chart = CategoricalChartData(
-        chartType="Line",
-        categories=["A"],
-        series=[CategoricalSeries(name="s", values=[1])],
-    )
-    with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=99))
-    assert exc.value.code == ErrorCode.INVALID_PARAM
-
-
 # ---------------------------------------------------------------------------
-# get_chart
+# get_chart_from_slide_base64 (was get_chart Path A)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_categorical_round_trip(empty_pptx: Path) -> None:
+async def test_get_categorical_round_trip() -> None:
     chart = CategoricalChartData(
         chartType="ColumnClustered",
         categories=["Q1", "Q2"],
@@ -156,10 +101,10 @@ async def test_get_categorical_round_trip(empty_pptx: Path) -> None:
         title="Year",
         showLegend=True,
     )
-    inserted = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
-    eid = inserted["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
+    eid = gen["elementId"]
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    got = await chart_engine.get_chart_from_slide_base64(gen["slideBase64"], eid)
     assert got["elementId"] == eid
     assert got["chart"]["chartType"] == "ColumnClustered"
     assert got["chart"]["categories"] == ["Q1", "Q2"]
@@ -170,93 +115,32 @@ async def test_get_categorical_round_trip(empty_pptx: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_scatter_round_trip(empty_pptx: Path) -> None:
-    chart = ScatterChartData(
-        chartType="Scatter",
-        series=[
-            ScatterSeries(
-                name="ads",
-                points=[ScatterPoint(x=1, y=10), ScatterPoint(x=2, y=20), ScatterPoint(x=3, y=40)],
-            )
-        ],
-        title="adv-vs-sales",
-    )
-    inserted = await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), inserted["elementId"])
-    assert got["chart"]["chartType"] == "Scatter"
-    assert got["chart"]["title"] == "adv-vs-sales"
-    pts = got["chart"]["series"][0]["points"]
-    assert pts == [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 20.0}, {"x": 3.0, "y": 40.0}]
-
-
-@pytest.mark.asyncio
-async def test_get_unknown_element_raises_3010(empty_pptx: Path) -> None:
+async def test_get_unknown_element_raises_3010() -> None:
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.get_chart(empty_pptx.as_uri(), "chart-99999")
+        await chart_engine.get_chart_from_slide_base64(_blank_slide_base64(), "chart-99999")
     assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND
 
 
 @pytest.mark.asyncio
-async def test_get_invalid_element_id_format_raises_3010(empty_pptx: Path) -> None:
+async def test_get_invalid_element_id_format_raises_3010() -> None:
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.get_chart(empty_pptx.as_uri(), "shape-1")
+        await chart_engine.get_chart_from_slide_base64(_blank_slide_base64(), "shape-1")
     assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND
 
 
 # ---------------------------------------------------------------------------
-# update_chart
+# update_chart_in_slide_base64 (was update_chart Path A)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_update_title_only(empty_pptx: Path) -> None:
-    chart = CategoricalChartData(
-        chartType="ColumnClustered",
-        categories=["A", "B"],
-        series=[CategoricalSeries(name="s", values=[1, 2])],
-        title="Original",
-    )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
-
-    upd = CategoricalChartUpdate(chartType="ColumnClustered", title="Revised")
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
-    assert "title" in result["updatedFields"]
-
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
-    assert got["chart"]["title"] == "Revised"
-
-
-@pytest.mark.asyncio
-async def test_update_replace_categorical_series(empty_pptx: Path) -> None:
+async def test_update_categorical_dimension_mismatch_raises_3015() -> None:
     chart = CategoricalChartData(
         chartType="ColumnClustered",
         categories=["A", "B"],
         series=[CategoricalSeries(name="s", values=[1, 2])],
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
-
-    upd = CategoricalChartUpdate(
-        chartType="ColumnClustered",
-        categories=["X", "Y", "Z"],
-        series=[CategoricalSeries(name="t", values=[10, 20, 30])],
-    )
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
-    assert "series" in result["updatedFields"]
-    assert "categories" in result["updatedFields"]
-
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
-    assert got["chart"]["categories"] == ["X", "Y", "Z"]
-    assert got["chart"]["series"][0]["values"] == [10.0, 20.0, 30.0]
-
-
-@pytest.mark.asyncio
-async def test_update_categorical_dimension_mismatch_raises_3015(empty_pptx: Path) -> None:
-    chart = CategoricalChartData(
-        chartType="ColumnClustered",
-        categories=["A", "B"],
-        series=[CategoricalSeries(name="s", values=[1, 2])],
-    )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, None))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
 
     upd = CategoricalChartUpdate(
         chartType="ColumnClustered",
@@ -264,55 +148,30 @@ async def test_update_categorical_dimension_mismatch_raises_3015(empty_pptx: Pat
         series=[CategoricalSeries(name="t", values=[10, 20])],  # 2 != 3
     )
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+        await chart_engine.update_chart_in_slide_base64(gen["slideBase64"], gen["elementId"], upd)
     assert exc.value.code == ErrorCode.INVALID_CHART_DATA
 
 
 @pytest.mark.asyncio
-async def test_cross_variant_categorical_to_scatter(empty_pptx: Path) -> None:
-    cat = CategoricalChartData(
-        chartType="ColumnClustered",
-        categories=["A", "B"],
-        series=[CategoricalSeries(name="s", values=[1, 2])],
-    )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), cat, ChartInsertOptions(slideIndex=0)))["elementId"]
-
-    upd = ScatterChartUpdate(
-        chartType="Scatter",
-        series=[ScatterSeries(name="conv", points=[ScatterPoint(x=1, y=10), ScatterPoint(x=2, y=20)])],
-    )
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
-    assert result["chartType"] == "Scatter"
-    assert "chartType" in result["updatedFields"]
-    assert "series" in result["updatedFields"]
-    new_eid = result["elementId"]
-
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), new_eid)
-    assert got["chart"]["chartType"] == "Scatter"
-
-
-@pytest.mark.asyncio
-async def test_cross_variant_scatter_to_categorical_requires_categories_and_series(
-    empty_pptx: Path,
-) -> None:
+async def test_cross_variant_scatter_to_categorical_requires_categories_and_series() -> None:
     sc = ScatterChartData(
         chartType="Scatter",
         series=[ScatterSeries(name="ads", points=[ScatterPoint(x=1, y=2)])],
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), sc, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(sc)
 
     # Only chartType — no series, no categories — should fail with 3015.
     upd = CategoricalChartUpdate(chartType="ColumnClustered")
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+        await chart_engine.update_chart_in_slide_base64(gen["slideBase64"], gen["elementId"], upd)
     assert exc.value.code == ErrorCode.INVALID_CHART_DATA
 
 
 @pytest.mark.asyncio
-async def test_update_unknown_element_raises_3010(empty_pptx: Path) -> None:
+async def test_update_unknown_element_raises_3010() -> None:
     upd = CategoricalChartUpdate(chartType="ColumnClustered", title="x")
     with pytest.raises(ChartEngineError) as exc:
-        await chart_engine.update_chart(empty_pptx.as_uri(), "chart-99999", upd)
+        await chart_engine.update_chart_in_slide_base64(_blank_slide_base64(), "chart-99999", upd)
     assert exc.value.code == ErrorCode.ELEMENT_NOT_FOUND
 
 
@@ -322,23 +181,24 @@ async def test_update_unknown_element_raises_3010(empty_pptx: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_insert_element_id_is_opaque_and_written_to_shape_name(empty_pptx: Path) -> None:
-    """Inserted chart's elementId is opaque and persisted as the shape name (cNvPr/@name)."""
+async def test_insert_element_id_is_opaque_and_written_to_shape_name() -> None:
+    """Generated chart's elementId is opaque and persisted as the shape name (cNvPr/@name)."""
     chart = CategoricalChartData(
         chartType="Line",
         categories=["A", "B"],
         series=[CategoricalSeries(name="s", values=[1, 2])],
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
+    eid = gen["elementId"]
     assert eid.startswith("oasp-chart-")
-    # The opaque id must survive save()/reload as the shape's OOXML name.
-    prs = Presentation(str(empty_pptx))
+    # The opaque id must survive encode/decode as the shape's OOXML name.
+    prs = Presentation(io.BytesIO(base64.b64decode(gen["slideBase64"])))
     names = [shape.name for slide in prs.slides for shape in slide.shapes if getattr(shape, "has_chart", False)]
     assert eid in names
 
 
 @pytest.mark.asyncio
-async def test_get_relocates_by_opaque_name_not_native_id(empty_pptx: Path) -> None:
+async def test_get_relocates_by_opaque_name_not_native_id() -> None:
     """After a second chart shifts native ids, get still finds the first chart by its opaque name."""
     chart = CategoricalChartData(
         chartType="ColumnClustered",
@@ -346,23 +206,23 @@ async def test_get_relocates_by_opaque_name_not_native_id(empty_pptx: Path) -> N
         series=[CategoricalSeries(name="s", values=[1, 2])],
         title="first",
     )
-    first = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
-    # Insert a second chart on the same slide (native shape ids advance).
-    await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0))
+    gen = await chart_engine.generate_chart_slide_base64(chart)
+    first = gen["elementId"]
+    # Insert a second chart onto the same slide (native shape ids advance).
+    second = await chart_engine.insert_chart_into_slide_base64(gen["slideBase64"], chart)
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), first)
+    got = await chart_engine.get_chart_from_slide_base64(second["slideBase64"], first)
     assert got["elementId"] == first
     assert got["chart"]["title"] == "first"
 
 
 @pytest.mark.asyncio
-async def test_legacy_chart_element_id_still_resolves(tmp_path: Path) -> None:
+async def test_legacy_chart_element_id_still_resolves() -> None:
     """A 0.2.0 chart (default python-pptx name, no opaque id) resolves via legacy chart-<slide>-<shape>."""
     from pptx.chart.data import CategoryChartData
     from pptx.enum.chart import XL_CHART_TYPE
     from pptx.util import Pt
 
-    path = tmp_path / "legacy.pptx"
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
     cd = CategoryChartData()
@@ -370,21 +230,22 @@ async def test_legacy_chart_element_id_still_resolves(tmp_path: Path) -> None:
     cd.add_series("s", (1, 2))
     shape: Any = slide.shapes.add_chart(XL_CHART_TYPE.COLUMN_CLUSTERED, Pt(10), Pt(10), Pt(300), Pt(200), cd)  # type: ignore[arg-type]
     legacy_eid = f"chart-0-{int(shape.shape_id)}"  # not written to shape.name
-    prs.save(str(path))
+    buf = io.BytesIO()
+    prs.save(buf)
+    slide_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
-    got = await chart_engine.get_chart(path.as_uri(), legacy_eid)
+    got = await chart_engine.get_chart_from_slide_base64(slide_b64, legacy_eid)
     assert got["chart"]["chartType"] == "ColumnClustered"
     assert got["chart"]["categories"] == ["A", "B"]
 
 
 @pytest.mark.asyncio
-async def test_legacy_chart_migrates_to_opaque_id_on_recreate(tmp_path: Path) -> None:
+async def test_legacy_chart_migrates_to_opaque_id_on_recreate() -> None:
     """A 0.2.0 (legacy-named) chart updated via a cross-variant recreate is migrated to a fresh opaque id."""
     from pptx.chart.data import CategoryChartData
     from pptx.enum.chart import XL_CHART_TYPE
     from pptx.util import Pt
 
-    path = tmp_path / "legacy.pptx"
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[5])
     cd = CategoryChartData()
@@ -392,44 +253,25 @@ async def test_legacy_chart_migrates_to_opaque_id_on_recreate(tmp_path: Path) ->
     cd.add_series("s", (1, 2))
     shape: Any = slide.shapes.add_chart(XL_CHART_TYPE.COLUMN_CLUSTERED, Pt(10), Pt(10), Pt(300), Pt(200), cd)  # type: ignore[arg-type]
     legacy_eid = f"chart-0-{int(shape.shape_id)}"  # default python-pptx name, NOT an opaque id
-    prs.save(str(path))
+    buf = io.BytesIO()
+    prs.save(buf)
+    slide_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
 
     upd = ScatterChartUpdate(
         chartType="Scatter",
         series=[ScatterSeries(name="p", points=[ScatterPoint(x=1, y=2), ScatterPoint(x=3, y=4)])],
     )
-    result = await chart_engine.update_chart(path.as_uri(), legacy_eid, upd)
+    result = await chart_engine.update_chart_in_slide_base64(slide_b64, legacy_eid, upd)
     new_eid = result["elementId"]
     assert new_eid.startswith("oasp-chart-")  # migrated off the legacy form
     assert new_eid != legacy_eid
 
     # The recreated chart now carries the opaque id in its OOXML name and is located by it.
-    got = await chart_engine.get_chart(path.as_uri(), new_eid)
+    got = await chart_engine.get_chart_from_slide_base64(result["slideBase64"], new_eid)
     assert got["chart"]["chartType"] == "Scatter"
-    prs_reloaded = Presentation(str(path))
+    prs_reloaded = Presentation(io.BytesIO(base64.b64decode(result["slideBase64"])))
     names = [s.name for sl in prs_reloaded.slides for s in sl.shapes if getattr(s, "has_chart", False)]
     assert new_eid in names
-
-
-@pytest.mark.asyncio
-async def test_update_preserves_opaque_element_id_across_recreate(empty_pptx: Path) -> None:
-    """Cross-variant update recreates the shape but keeps the same opaque elementId."""
-    cat = CategoricalChartData(
-        chartType="ColumnClustered",
-        categories=["A", "B"],
-        series=[CategoricalSeries(name="s", values=[1, 2])],
-    )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), cat, ChartInsertOptions(slideIndex=0)))["elementId"]
-
-    upd = ScatterChartUpdate(
-        chartType="Scatter",
-        series=[ScatterSeries(name="p", points=[ScatterPoint(x=1, y=2), ScatterPoint(x=3, y=4)])],
-    )
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
-    assert result["elementId"] == eid  # stable across delete-and-recreate
-
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
-    assert got["chart"]["chartType"] == "Scatter"
 
 
 # ---------------------------------------------------------------------------
@@ -619,7 +461,7 @@ async def test_insert_into_base64_with_no_slides_raises_4002() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_title_explicit_none_deletes_title(empty_pptx: Path) -> None:
+async def test_update_title_explicit_none_deletes_title() -> None:
     """Explicit ``title=None`` (present in model_fields_set) removes the chart title."""
     chart = CategoricalChartData(
         chartType="ColumnClustered",
@@ -627,19 +469,20 @@ async def test_update_title_explicit_none_deletes_title(empty_pptx: Path) -> Non
         series=[CategoricalSeries(name="s", values=[1, 2])],
         title="Original",
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
+    eid = gen["elementId"]
 
     # model_validate guarantees "title" lands in model_fields_set even though the value is None.
     upd = CategoricalChartUpdate.model_validate({"chartType": "ColumnClustered", "title": None})
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    result = await chart_engine.update_chart_in_slide_base64(gen["slideBase64"], eid, upd)
     assert "title" in result["updatedFields"]
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    got = await chart_engine.get_chart_from_slide_base64(result["slideBase64"], eid)
     assert got["chart"]["title"] is None
 
 
 @pytest.mark.asyncio
-async def test_update_data_only_preserves_existing_title(empty_pptx: Path) -> None:
+async def test_update_data_only_preserves_existing_title() -> None:
     """A series-only update (title absent from model_fields_set) must NOT wipe the title."""
     chart = CategoricalChartData(
         chartType="ColumnClustered",
@@ -647,20 +490,21 @@ async def test_update_data_only_preserves_existing_title(empty_pptx: Path) -> No
         series=[CategoricalSeries(name="s", values=[1, 2])],
         title="Keep Me",
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
+    eid = gen["elementId"]
 
     upd = CategoricalChartUpdate(chartType="ColumnClustered", series=[CategoricalSeries(name="s", values=[9, 8])])
-    result = await chart_engine.update_chart(empty_pptx.as_uri(), eid, upd)
+    result = await chart_engine.update_chart_in_slide_base64(gen["slideBase64"], eid, upd)
     assert "title" not in result["updatedFields"]
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    got = await chart_engine.get_chart_from_slide_base64(result["slideBase64"], eid)
     assert got["chart"]["title"] == "Keep Me"
     assert got["chart"]["series"][0]["values"] == [9.0, 8.0]
 
 
 @pytest.mark.asyncio
-async def test_display_options_round_trip(empty_pptx: Path) -> None:
-    """showLegend / showDataLabels written on insert are read back faithfully."""
+async def test_display_options_round_trip() -> None:
+    """showLegend / showDataLabels written on generate are read back faithfully."""
     chart = CategoricalChartData(
         chartType="ColumnClustered",
         categories=["A", "B"],
@@ -668,15 +512,15 @@ async def test_display_options_round_trip(empty_pptx: Path) -> None:
         showLegend=True,
         showDataLabels=True,
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    got = await chart_engine.get_chart_from_slide_base64(gen["slideBase64"], gen["elementId"])
     assert got["chart"]["showLegend"] is True
     assert got["chart"]["showDataLabels"] is True
 
 
 @pytest.mark.asyncio
-async def test_display_options_legend_off_round_trip(empty_pptx: Path) -> None:
+async def test_display_options_legend_off_round_trip() -> None:
     """showLegend=False is honoured (not just the True case)."""
     chart = CategoricalChartData(
         chartType="Pie",
@@ -684,7 +528,7 @@ async def test_display_options_legend_off_round_trip(empty_pptx: Path) -> None:
         series=[CategoricalSeries(name="s", values=[1, 2])],
         showLegend=False,
     )
-    eid = (await chart_engine.insert_chart(empty_pptx.as_uri(), chart, ChartInsertOptions(slideIndex=0)))["elementId"]
+    gen = await chart_engine.generate_chart_slide_base64(chart)
 
-    got = await chart_engine.get_chart(empty_pptx.as_uri(), eid)
+    got = await chart_engine.get_chart_from_slide_base64(gen["slideBase64"], gen["elementId"])
     assert got["chart"]["showLegend"] is False


### PR DESCRIPTION
## 目标

`chart` 三工具（`ppt_insert_chart` / `ppt_get_chart` / `ppt_update_chart`）此前双路径：CONNECTED 走 Add-In 客户端往返（Path B），DISCONNECTED 走 Server 端 on-disk python-pptx（Path A）。离线出图/改图能力已由 authoring 流水线（`office_run_script` + python-pptx）承接，故**删除 Path A，收敛为「仅连接态单路径」**，与 W4a 二元工具收敛模型（#63）一致。

milestone #4 · Part of #56 · **Closes #68**

## 变更

- **chart_engine**：删除 `insert_chart` / `get_chart` / `update_chart`（uri 版）+ `_*_chart_blocking` + `_uri_to_path`；OOXML core 与 base64（Path B 内存）helper 完整保留。
- **三工具收敛单路径**：
  - `DISCONNECTED` → `OFFLINE_MESSAGE`（引导 `office_run_script` 走 authoring）
  - `CONNECTED` 但缺 `slideIndex` → `LIVE_NEEDS_SLIDE_INDEX`
  - `CONNECTED` 但 Path B 尚不可用 → `DEGRADE_MESSAGE`（旧 `DEGRADE_MESSAGE_WRITE`「关文档服务端落盘」的失效承诺已消除）
- **文案同步**：工具 `description` / DTO 字段 / 模块 docstring / `document_lock` 去除 on-disk/离线误导；`element_id` 说明改为 opaque `oasp-chart-<uuid>`。
- **测试**：engine 侧 Path A→base64 迁移（DROP 9 / MIGRATE 17，覆盖不弱化）；工具侧改 refuse 语义，保留连接态 happy / degrade / business-error（3010/3015/3004 如实透传，不被 3003 吞掉）/ 文档锁串行化不变量；新增 DISCONNECTED→OFFLINE 用例。

## 门控

- **协议归属**：无 OASP 协议改动（Path A 无 Socket.IO 事件，Path B 的 `ppt:get/insert:slidesOoxml` 未动）。
- **体验门控**：关闭文档上的 chart 调用 → refuse + 引导 authoring（已与维护者拍板）。
- **隔离 code-review**：🔴 阻断项 0；🟡 全部 + 相关 🟢 已修。

## 验证

`ruff` ✅ · `mypy` ✅（154 files）· `pytest` **1802 passed, 3 skipped**。净 -421 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)