### PR TITLE
fix(authoring): 沙箱预热受信重库，修 openpyxl→numpy 被 ctypes 拦 (#71)

### DIFF
--- a/office4ai/office/authoring/_sandbox_child.py
+++ b/office4ai/office/authoring/_sandbox_child.py
@@ -12,10 +12,11 @@
     1. 读取 config（此时尚未装 audit hook，父进程写的 config 文件可自由读）；
     2. 设置 RLIMIT（内存/CPU/文件大小，作为父进程 wall-clock 杀进程组之外的兜底）；
     3. chdir 进 work_dir；
-    4. 装 audit hook（FS 写越权 / 进程逃逸 / ctypes 拦截）——**装之后本进程所有操作都受管**；
-    5. monkeypatch socket egress 实现「默认禁网」；
-    6. 构造受限 builtins（用户帧 ``__import__`` allowlist）；
-    7. ``exec`` 用户脚本，异常打到 stderr 并以非零码退出。
+    4. 预热 import 受信重库（``openpyxl → numpy`` 等，其 import 期的 ``ctypes.dlopen`` 须在装 hook 前完成）；
+    5. 装 audit hook（FS 写越权 / 进程逃逸 / ctypes 拦截）——**装之后本进程所有操作都受管**；
+    6. monkeypatch socket egress 实现「默认禁网」；
+    7. 构造受限 builtins（用户帧 ``__import__`` allowlist）；
+    8. ``exec`` 用户脚本，异常打到 stderr 并以非零码退出。
 
 软沙箱定位：拦截「误操作 / 明显越权」（死循环、越权写、联网、逃逸），
 而非对抗性 RCE。留 OS 级加固接缝（Linux bubblewrap/nsjail）由后续演进。
@@ -205,6 +206,28 @@ def _set_rlimits(mem_bytes: int, cpu_seconds: int, fsize_bytes: int) -> None:
             continue
 
 
+def _warmup_trusted_libs(names: list[str]) -> None:
+    """在装 audit hook 前预热 import 受信重库（best-effort）。
+
+    这些库（如 ``openpyxl → numpy``）在 import 期会触发 ``ctypes.dlopen`` 等被沙箱拦截的
+    操作——若发生在 hook 之后会抛 :class:`SandboxViolation`。预热在受信阶段完成其模块
+    初始化（含 ``ctypes`` 模块自身首次 import 的 dlopen），之后用户脚本 ``import`` 命中
+    ``sys.modules`` 缓存不再触发。**安全不变**：用户脚本自身对 ctypes 的直接 import
+    （allowlist）与调用（audit ``ctypes.dlopen``）仍照常拦截。``names`` 由父进程按受信库
+    白名单下发（``allowed_imports`` 与原生库集合的交集），用户脚本无法影响。
+
+    仅在运行时用 ``importlib`` 动态 import 第三方库（本模块的静态依赖仍只有标准库）；
+    单库失败静默跳过，真错误留待用户脚本自身 import 时暴露。
+    """
+    import importlib
+
+    for name in names:
+        try:
+            importlib.import_module(name)
+        except Exception:  # noqa: BLE001 - best-effort 预热，失败留给用户脚本 import 时暴露
+            continue
+
+
 def main() -> int:
     with open(sys.argv[1], encoding="utf-8") as fh:
         cfg = json.load(fh)
@@ -223,6 +246,10 @@ def main() -> int:
     )
 
     os.chdir(work_dir)
+
+    # 预热受信重库（须在装 hook 前）：openpyxl→numpy 等 import 期会触发 ctypes.dlopen，
+    # 装 hook 后会被拦成 SandboxViolation；预热后用户脚本 import 命中缓存不再触发。
+    _warmup_trusted_libs(cfg.get("warmup_imports", []))
 
     # —— 自此以下装上守卫，用户脚本全程受管 ——
     _install_audit_hook(write_allow, allowed_execs)

--- a/office4ai/office/authoring/_sandbox_child.py
+++ b/office4ai/office/authoring/_sandbox_child.py
@@ -212,19 +212,26 @@ def _warmup_trusted_libs(names: list[str]) -> None:
     这些库（如 ``openpyxl → numpy``）在 import 期会触发 ``ctypes.dlopen`` 等被沙箱拦截的
     操作——若发生在 hook 之后会抛 :class:`SandboxViolation`。预热在受信阶段完成其模块
     初始化（含 ``ctypes`` 模块自身首次 import 的 dlopen），之后用户脚本 ``import`` 命中
-    ``sys.modules`` 缓存不再触发。**安全不变**：用户脚本自身对 ctypes 的直接 import
-    （allowlist）与调用（audit ``ctypes.dlopen``）仍照常拦截。``names`` 由父进程按受信库
-    白名单下发（``allowed_imports`` 与原生库集合的交集），用户脚本无法影响。
+    ``sys.modules`` 缓存不再触发。``names`` 由父进程按受信库白名单下发（``allowed_imports``
+    与原生库集合的交集），用户脚本无法影响。
+
+    **安全语义**（软沙箱、非对抗性 RCE）：预热把 ctypes 等送进 ``sys.modules`` **不扩大
+    对抗面**——本沙箱的 import allowlist 与 audit hook 均是 defense-in-depth 而非硬边界
+    （真实隔离留给 OS 级加固接缝）。用户帧 ``import ctypes`` 仍被 allowlist 挡；用户对
+    ctypes 的**会发 audit 事件**的危险操作（``dlopen`` / ``dlsym`` / ``call_function`` 等）
+    仍被进程级 hook 拦，无论经何种途径取到 ctypes 模块对象。
 
     仅在运行时用 ``importlib`` 动态 import 第三方库（本模块的静态依赖仍只有标准库）；
-    单库失败静默跳过，真错误留待用户脚本自身 import 时暴露。
+    单库失败打一行 stderr 诊断并跳过——对预热的原生库，失败会让它在 hook 装好后 import
+    时触到 ctypes 拦截成误导性的 SandboxViolation，故此诊断有助排查。
     """
     import importlib
 
     for name in names:
         try:
             importlib.import_module(name)
-        except Exception:  # noqa: BLE001 - best-effort 预热，失败留给用户脚本 import 时暴露
+        except Exception as exc:  # noqa: BLE001 - best-effort 预热；失败打诊断后继续
+            print(f"[sandbox] warmup import {name!r} failed: {type(exc).__name__}: {exc}", file=sys.stderr)
             continue
 
 

--- a/office4ai/office/authoring/runtime.py
+++ b/office4ai/office/authoring/runtime.py
@@ -105,6 +105,14 @@ DEFAULT_ALLOWED_IMPORTS: tuple[str, ...] = (
     "xml",
 )
 
+#: 需在装 audit hook 前**预热 import** 的受信原生/重库子集。这些库在 import 期会触发被沙箱
+#: 拦截的操作——典型是 ``openpyxl → numpy``，numpy import 期的传递 ``import ctypes`` 会触发
+#: ctypes 模块初始化的 ``ctypes.dlopen``（Linux 上加载 libpython/libc），被 audit hook 拦成
+#: ``SandboxViolation``。预热在受信阶段完成其模块初始化后，用户脚本再 import 命中 ``sys.modules``
+#: 缓存不再触发；用户脚本自身仍无法 ``import ctypes``（allowlist）或调用 ``ctypes.dlopen``
+#: （audit hook 仍生效）。名单是 ``allowed_imports`` 与本集合的交集，用户脚本无法影响。
+_NATIVE_WARMUP_LIBS: frozenset[str] = frozenset({"docx", "pptx", "openpyxl", "lxml", "docxtpl", "jinja2", "PIL"})
+
 _CHILD_PATH = Path(__file__).with_name("_sandbox_child.py")
 
 # soffice 探测候选（含 macOS app bundle 内路径）
@@ -268,9 +276,22 @@ _ENV_ALLOWLIST: tuple[str, ...] = (
 )
 
 
+#: 强制沙箱内的数值库（numpy/BLAS/OpenMP）单线程。预热 import numpy 会拉起 OpenBLAS
+#: 线程池，部分构建会 busy-spin 空转烧 CPU——多核下会让 ``RLIMIT_CPU``(SIGXCPU) 先于
+#: wall-clock 超时触发，且平白吃掉脚本的 CPU 预算。沙箱化的文档脚本无需并行 BLAS。
+_SINGLE_THREAD_ENV: dict[str, str] = {
+    "OMP_NUM_THREADS": "1",
+    "OPENBLAS_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "NUMEXPR_NUM_THREADS": "1",
+    "VECLIB_MAXIMUM_THREADS": "1",  # macOS Accelerate/vecLib
+}
+
+
 def _child_env() -> dict[str, str]:
     env = {k: os.environ[k] for k in _ENV_ALLOWLIST if k in os.environ}
     env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env.update(_SINGLE_THREAD_ENV)
     return env
 
 
@@ -319,6 +340,8 @@ async def run_script(
         "work_dir": str(wd),
         "write_allow": [str(wd)],
         "allowed_imports": list(allowed_imports),
+        # 装 audit hook 前预热的受信重库（openpyxl→numpy 等 import 期会 ctypes.dlopen）。
+        "warmup_imports": [name for name in allowed_imports if name in _NATIVE_WARMUP_LIBS],
         "allowed_executables": [soffice] if soffice else [],
         "block_network": True,
         "cpu_limit_seconds": int(timeout) + 5,

--- a/tests/unit_tests/office4ai/office/authoring/test_runtime.py
+++ b/tests/unit_tests/office4ai/office/authoring/test_runtime.py
@@ -185,3 +185,50 @@ async def test_default_work_dir_is_created() -> None:
             for p in Path(result.path).iterdir():
                 p.unlink()
             Path(result.path).rmdir()
+
+
+# ---------------------------------------------------------------------------
+# ctypes 预热修复（#71）：装 audit hook 前预热受信重库，令 openpyxl→numpy 的
+# import 期 ctypes.dlopen 在受信阶段完成；用户脚本自身仍无法 import/用 ctypes。
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_libs_declared_for_native_deps() -> None:
+    from office4ai.office.authoring.runtime import _NATIVE_WARMUP_LIBS
+
+    # 预热集必须是 allowlist 的子集（不会预热一个用户脚本本就不能 import 的库）。
+    assert _NATIVE_WARMUP_LIBS <= set(DEFAULT_ALLOWED_IMPORTS)
+    # openpyxl（→numpy）是本 bug 的直接触发库，必须在预热名单内。
+    assert "openpyxl" in _NATIVE_WARMUP_LIBS
+    # 父进程下发给子进程的 warmup 列表 = allowed_imports ∩ 原生库集合。
+    warmup = [name for name in DEFAULT_ALLOWED_IMPORTS if name in _NATIVE_WARMUP_LIBS]
+    assert "openpyxl" in warmup
+    assert "os" not in warmup  # 纯 stdlib 不预热
+
+
+async def test_openpyxl_workbook_runs_in_sandbox(tmp_path: Path) -> None:
+    # 回归 #71：openpyxl 在 Linux 上 import 期经 numpy 触发 ctypes.dlopen，预热前会被
+    # 沙箱拦成 SandboxViolation。本用例是该修复的端到端守护（Linux CI 上才能区分成败）。
+    script = "from openpyxl import Workbook\nwb = Workbook()\nwb.active['A1'] = 'hi'\nwb.save('out.xlsx')\n"
+    result = await run_script(script, work_dir=tmp_path)
+    assert result.ok is True, result.stderr
+    assert (tmp_path / "out.xlsx").exists()
+
+
+async def test_user_script_cannot_import_ctypes_even_after_warmup(tmp_path: Path) -> None:
+    # 安全回归：预热可能把 ctypes 经 numpy 送进 sys.modules，但用户帧 import 仍受 allowlist
+    # 门控（与 sys.modules 缓存无关），故用户脚本依然无法 import ctypes。
+    result = await run_script("import ctypes\n", work_dir=tmp_path)
+    assert result.ok is False
+    assert "ctypes" in result.stderr
+    assert "not allowed" in result.stderr
+
+
+def test_warmup_trusted_libs_is_best_effort() -> None:
+    import sys
+
+    from office4ai.office.authoring._sandbox_child import _warmup_trusted_libs
+
+    # 未知库静默跳过（不抛），已知库被导入进 sys.modules。
+    _warmup_trusted_libs(["base64", "office4ai_no_such_lib_zzz"])
+    assert "base64" in sys.modules

--- a/tests/unit_tests/office4ai/office/authoring/test_runtime.py
+++ b/tests/unit_tests/office4ai/office/authoring/test_runtime.py
@@ -232,3 +232,30 @@ def test_warmup_trusted_libs_is_best_effort() -> None:
     # 未知库静默跳过（不抛），已知库被导入进 sys.modules。
     _warmup_trusted_libs(["base64", "office4ai_no_such_lib_zzz"])
     assert "base64" in sys.modules
+
+
+async def test_user_script_cannot_use_ctypes_via_sys_modules_bypass(tmp_path: Path) -> None:
+    # 预热可能把 ctypes 经 numpy 送进子进程 sys.modules。即便用户脚本绕过 import allowlist
+    # 直接经 sys.modules 取到 ctypes，任何 dlopen/CDLL 仍触发进程级 audit hook 被拦——这是
+    # 本 PR 新增可达性的精确守护。跨平台成立：Linux（已预热）走 audit 拦截；macOS（未预热）
+    # sys.modules 无 ctypes → KeyError；两路都是「用户拿不到可用的 ctypes」。
+    script = "import sys\nsys.modules['ctypes'].CDLL(None)\n"
+    result = await run_script(script, work_dir=tmp_path)
+    assert result.ok is False
+    assert "ctypes" in result.stderr
+
+
+def test_child_env_pins_single_thread_blas() -> None:
+    # 预热 numpy 会拉起 OpenBLAS 线程池 busy-spin；子进程 env 必须封顶到单线程，
+    # 否则 RLIMIT_CPU(SIGXCPU) 会先于 wall-clock 超时触发。
+    from office4ai.office.authoring.runtime import _child_env
+
+    env = _child_env()
+    for var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+    ):
+        assert env[var] == "1", var


### PR DESCRIPTION
## 根因

authoring 沙箱（S1 #57）的 audit hook 对**任何** `ctypes.*` 事件一律 `SandboxViolation`。而 `openpyxl → numpy` 在 import 期的传递 `import ctypes` 会触发 `ctypes` 模块初始化的 `ctypes.dlopen`（Linux 上加载 libpython/libc），被拦成 `SandboxViolation`。

后果：**excel 脚本化创建（W1）在 Linux 全线不可用**，集成测试 `test_gen_excel_from_scratch` 挂 → **main CI 连续红 5+ 提交**。macOS 本地 numpy import 不触发同一 audit 事件，故本地假绿掩盖问题。

## 修复

装 audit hook **之前**预热 import 受信重库（`allowed_imports ∩ {docx,pptx,openpyxl,lxml,docxtpl,jinja2,PIL}`），令其 import 期的 ctypes 操作在受信阶段完成；用户脚本再 import 命中 `sys.modules` 缓存不再触发。

**安全不变**：
- 用户脚本自身仍**无法 `import ctypes`**——`_guarded_import` 的 allowlist 门控在**用户帧**生效，与 `sys.modules` 缓存无关（`ctypes` 不在 allowlist）。
- 用户脚本仍**无法调用 `ctypes.dlopen`/`CDLL`**——audit hook 在用户脚本全程生效，任何 `ctypes.*` 操作仍被拦（`test_ctypes_blocked` 守护）。
- warmup 名单由父进程按受信库白名单下发，用户脚本无法影响。

## 附带修复：数值库单线程

预热 `numpy` 会拉起 OpenBLAS 线程池，部分构建 busy-spin 空转烧 CPU——多核下让 `RLIMIT_CPU`(SIGXCPU) **先于 wall-clock 超时**触发（并平白吃掉脚本 CPU 预算）。在子进程 env 强制 `OMP/OPENBLAS/MKL/NUMEXPR/VECLIB_NUM_THREADS=1`，wall-clock 超时重新成为主杀手。沙箱化文档脚本本就无需并行 BLAS。

## 测试

- warmup 名单声明（父侧，跨平台）
- `openpyxl` 建 xlsx 端到端（**Linux CI 才能区分成败**——本 PR 的真验收）
- 用户脚本仍无法 `import ctypes`（安全回归）
- warmup best-effort（未知库静默跳过）
- 既有 `test_ctypes_blocked` / 无限循环超时用例仍绿

`ruff` ✅ · `mypy` ✅(154) · `pytest` **1821 passed, 3 skipped**。

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)