### PR TITLE
feat(dtos): #74 #45 /word+/ppt 字体收敛为 WordFont/PptFont，跟进 OASP 0.4.0 [HELD 待协议发版]

### DIFF
--- a/office4ai/__init__.py
+++ b/office4ai/__init__.py
@@ -16,7 +16,7 @@ Main Components:
 - PresentationHandler: PowerPoint presentation operations
 """
 
-__version__: str = "0.3.0"
+__version__: str = "0.4.0"
 __all__ = [
     "__version__",
 ]

--- a/office4ai/a2c_smcp/tools/ppt/insert_text.py
+++ b/office4ai/a2c_smcp/tools/ppt/insert_text.py
@@ -15,7 +15,10 @@ class PptInsertTextInput(BaseModel):
 
     document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/presentation.pptx)")
     text: str = Field(..., description="Text to insert")
-    options: TextInsertOptions | None = Field(None, description="Insertion options (position, size, font, color)")
+    options: TextInsertOptions | None = Field(
+        None,
+        description="Insertion options (position, size, fillColor, font: PptFont with size/name/color/bold/italic/underline/...)",
+    )
 
 
 class PptInsertTextTool(BaseTool):

--- a/office4ai/a2c_smcp/tools/ppt/update_text_box.py
+++ b/office4ai/a2c_smcp/tools/ppt/update_text_box.py
@@ -15,7 +15,14 @@ class PptUpdateTextBoxInput(BaseModel):
 
     document_uri: str = Field(..., description="Target document URI (e.g. file:///path/to/presentation.pptx)")
     elementId: str | int = Field(..., description="Element ID to update")
-    updates: TextBoxUpdates = Field(..., description="Updates to apply (text, fontSize, fontName, color, bold, italic)")
+    updates: TextBoxUpdates = Field(
+        ...,
+        description=(
+            "Updates to apply: text, fillColor, font (PptFont: size, name, color, bold, italic, underline, "
+            "strikethrough, doubleStrikethrough, superscript, subscript, allCaps, smallCaps), "
+            "runs (run-level [{start, length, font}]), paragraphs (bullet [{start, length, bulletFormat}])."
+        ),
+    )
 
     # OF4AI-8: LLM 将纯数字字符串 ID（如 "5"）推断为 int，需强转回 str 以通过下游 DTO 校验
     @field_validator("elementId", mode="before")

--- a/office4ai/a2c_smcp/tools/word/append_text.py
+++ b/office4ai/a2c_smcp/tools/word/append_text.py
@@ -19,7 +19,13 @@ class WordAppendTextInput(BaseModel):
         default="End",
         description="Append location: Start (beginning of document) or End (end of document)",
     )
-    format: TextFormat | None = Field(None, description="Text formatting options (bold, italic, fontSize, etc.)")
+    format: TextFormat | None = Field(
+        None,
+        description=(
+            "Text formatting. Font attributes go under 'font' (WordFont: bold, italic, underline, size, "
+            "name, color, highlightColor); optional 'styleName'. Example: {'font': {'bold': true, 'size': 14}}."
+        ),
+    )
 
 
 class WordAppendTextTool(BaseTool):

--- a/office4ai/a2c_smcp/tools/word/insert_text.py
+++ b/office4ai/a2c_smcp/tools/word/insert_text.py
@@ -19,7 +19,13 @@ class WordInsertTextInput(BaseModel):
         default="Cursor",
         description="Insertion location: Cursor (at current cursor), Start (beginning of document), End (end of document)",
     )
-    format: TextFormat | None = Field(None, description="Text formatting options (bold, italic, fontSize, etc.)")
+    format: TextFormat | None = Field(
+        None,
+        description=(
+            "Text formatting. Font attributes go under 'font' (WordFont: bold, italic, underline, size, "
+            "name, color, highlightColor); optional 'styleName'. Example: {'font': {'bold': true, 'size': 14}}."
+        ),
+    )
 
 
 class WordInsertTextTool(BaseTool):

--- a/office4ai/a2c_smcp/tools/word/replace_text.py
+++ b/office4ai/a2c_smcp/tools/word/replace_text.py
@@ -37,7 +37,10 @@ class WordReplaceTextInput(BaseModel):
     )
     format: TextFormat | None = Field(
         None,
-        description="Text formatting to apply to the replaced text (bold, italic, fontSize, etc.)",
+        description=(
+            "Text formatting to apply to the replaced text. Font attributes go under 'font' "
+            "(WordFont: bold, italic, underline, size, name, color, highlightColor); optional 'styleName'."
+        ),
     )
 
 

--- a/office4ai/a2c_smcp/tools/word/update_table_cell.py
+++ b/office4ai/a2c_smcp/tools/word/update_table_cell.py
@@ -26,9 +26,9 @@ class WordUpdateTableCellInput(BaseModel):
         ...,
         description=(
             "Cells to update. Each entry needs rowIndex / columnIndex and at least one of "
-            "text / format. format supports backgroundColor, fontName, fontSize, fontColor, "
-            "bold, italic, horizontalAlignment ('Left' | 'Centered' | 'Right' | 'Justified'), "
-            "verticalAlignment ('Top' | 'Center' | 'Bottom')."
+            "text / format. format = { backgroundColor, font (WordFont: bold, italic, underline, size, "
+            "name, color, highlightColor), horizontalAlignment ('Left' | 'Centered' | 'Right' | 'Justified'), "
+            "verticalAlignment ('Top' | 'Center' | 'Bottom') }."
         ),
         min_length=1,
     )

--- a/office4ai/environment/workspace/dtos/ppt.py
+++ b/office4ai/environment/workspace/dtos/ppt.py
@@ -167,9 +167,121 @@ class PptInsertShapeRequest(BaseRequest):
     options: Optional["ShapeInsertOptions"] = Field(default=None, description="Insertion options")
 
 
+# ============================================================================
+# Font abstraction (PptFont) + text formatting — OASP 0.4.0
+# 字体属性收敛为 PptFont 子对象，文本框（整框 / run 级）与表格单元格复用。对齐 office.js。
+# ============================================================================
+
+# PPT 下划线样式（对齐 office.js ShapeFontUnderlineStyle，17 值 PascalCase，双端零映射）。
+ShapeFontUnderlineStyle = Literal[
+    "None",
+    "Single",
+    "Double",
+    "Heavy",
+    "Dotted",
+    "DottedHeavy",
+    "Dash",
+    "DashHeavy",
+    "DashLong",
+    "DashLongHeavy",
+    "DotDash",
+    "DotDashHeavy",
+    "DotDotDash",
+    "DotDotDashHeavy",
+    "Wavy",
+    "WavyHeavy",
+    "WavyDouble",
+]
+
+# 段落 / 单元格水平对齐（office.js ParagraphHorizontalAlignment，7 值，PowerPointApi 1.9）。
+ParagraphHorizontalAlignment = Literal[
+    "Left",
+    "Center",
+    "Right",
+    "Justify",
+    "JustifyLow",
+    "Distributed",
+    "ThaiDistributed",
+]
+
+# 文本 / 单元格垂直对齐（office.js TextVerticalAlignment，6 值，PowerPointApi 1.9）。
+TextVerticalAlignment = Literal[
+    "Top",
+    "Middle",
+    "Bottom",
+    "TopCentered",
+    "MiddleCentered",
+    "BottomCentered",
+]
+
+# 项目符号类型（office.js，PowerPointApi 1.10）。
+BulletType = Literal["None", "Numbered", "Unnumbered", "Unsupported"]
+
+
+class PptFont(SocketIOBaseModel):
+    """
+    PPT 字体格式（OASP 0.4.0）。文本框整框级 / run 级 / 表格单元格复用同一结构。
+    对齐 office.js ShapeFont，双端零映射。所有字段可选，未提供的属性保持原样。
+
+    requirement set（文本框语境）：size/name/color/bold/italic/underline = 1.4；
+    strikethrough/doubleStrikethrough/superscript/subscript/allCaps/smallCaps = 1.8。
+    用于 ppt:update:tableFormat 时经 TableCell.font 整体抬平到 1.9。
+    """
+
+    size: float | None = Field(default=None, alias="size", description="Font size (points), positive number", gt=0)
+    name: str | None = Field(default=None, alias="name", description="Font family name")
+    color: str | None = Field(default=None, alias="color", description="Font color (hex, e.g. '#333333')")
+    bold: bool | None = Field(default=None, alias="bold", description="Bold text")
+    italic: bool | None = Field(default=None, alias="italic", description="Italic text")
+    underline: ShapeFontUnderlineStyle | None = Field(
+        default=None, alias="underline", description="Underline style (17-value PascalCase enum) [1.4]"
+    )
+    strikethrough: bool | None = Field(default=None, alias="strikethrough", description="Strikethrough [1.8]")
+    double_strikethrough: bool | None = Field(
+        default=None, alias="doubleStrikethrough", description="Double strikethrough [1.8]"
+    )
+    superscript: bool | None = Field(default=None, alias="superscript", description="Superscript [1.8]")
+    subscript: bool | None = Field(default=None, alias="subscript", description="Subscript [1.8]")
+    all_caps: bool | None = Field(default=None, alias="allCaps", description="All caps [1.8]")
+    small_caps: bool | None = Field(default=None, alias="smallCaps", description="Small caps [1.8]")
+
+
+class BulletFormat(SocketIOBaseModel):
+    """
+    段落项目符号格式（对齐 office.js paragraphFormat.bulletFormat）。
+    仅 visible / type / style 可写；无 character / 字体 / 颜色。
+    """
+
+    visible: bool | None = Field(default=None, alias="visible", description="Show/hide bullet [1.4]")
+    bullet_type: BulletType | None = Field(
+        default=None, alias="type", description="Bullet type (None/Numbered/Unnumbered/Unsupported) [1.10]"
+    )
+    style: str | None = Field(
+        default=None,
+        alias="style",
+        description="Numbering/symbol style, aligned to office.js bullet style enum (e.g. 'ArabicNumeralPeriod') [1.10]",
+    )
+
+
+class PptTextRun(SocketIOBaseModel):
+    """run 级局部格式：对文本框内一段字符区间单独设置字体。"""
+
+    start: int = Field(..., alias="start", description="Start char index (0-based, UTF-16 code unit)", ge=0)
+    length: int = Field(..., alias="length", description="Char count (UTF-16 code unit)", ge=0)
+    font: PptFont = Field(..., alias="font", description="Font applied to this character range")
+
+
+class PptParagraphStyle(SocketIOBaseModel):
+    """段落级格式（当前仅项目符号），以字符区间寻址其接触到的段落。"""
+
+    start: int = Field(..., alias="start", description="Start char index (0-based, UTF-16 code unit)", ge=0)
+    length: int = Field(..., alias="length", description="Char count (UTF-16 code unit)", ge=0)
+    bullet_format: BulletFormat = Field(..., alias="bulletFormat", description="Bullet format for the paragraph(s)")
+
+
 class TextInsertOptions(SocketIOBaseModel):
     """
-    Text insertion options.
+    Text insertion options (OASP 0.4.0). Font attributes consolidated under ``font`` (PptFont).
     """
 
     slide_index: int | None = Field(default=None, alias="slideIndex", description="Slide index (default: current)")
@@ -177,14 +289,12 @@ class TextInsertOptions(SocketIOBaseModel):
     top: float | None = Field(default=None, description="Top position (points)")
     width: float | None = Field(default=None, description="Width (points)")
     height: float | None = Field(default=None, description="Height (points)")
-    font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
-    font_name: str | None = Field(default=None, alias="fontName", description="Font name")
-    color: str | None = Field(default=None, description="Font color (hex, e.g. '#333333')")
     fill_color: str | None = Field(
         default=None,
         alias="fillColor",
         description="Text box fill color (hex). Omit for no fill (default); 'none' to explicitly disable.",
     )
+    font: PptFont | None = Field(default=None, alias="font", description="Font formatting applied to the inserted text")
     border_color: str | None = Field(
         default=None,
         alias="borderColor",
@@ -302,16 +412,24 @@ class PptUpdateTextBoxRequest(BaseRequest):
 
 class TextBoxUpdates(SocketIOBaseModel):
     """
-    Text box update fields.
+    Text box update fields (OASP 0.4.0). Font consolidated under ``font``; run-level via ``runs``,
+    paragraph bullet via ``paragraphs``. Application order: text → font → runs → paragraphs
+    (run/paragraph ``start``/``length`` align to the final text after any ``text`` replacement).
     """
 
-    text: str | None = Field(default=None, description="New text content")
-    font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
-    font_name: str | None = Field(default=None, alias="fontName", description="Font name")
-    color: str | None = Field(default=None, description="Font color (hex)")
-    fill_color: str | None = Field(default=None, alias="fillColor", description="Fill color (hex)")
-    bold: bool | None = Field(default=None, description="Bold text")
-    italic: bool | None = Field(default=None, description="Italic text")
+    text: str | None = Field(default=None, description="New text content (whole box)")
+    fill_color: str | None = Field(default=None, alias="fillColor", description="Text box fill color (hex)")
+    font: PptFont | None = Field(default=None, alias="font", description="Whole-box font formatting (base layer)")
+    runs: list[PptTextRun] | None = Field(
+        default=None,
+        alias="runs",
+        description="Run-level local formatting (char-range addressed; later runs override earlier overlaps)",
+    )
+    paragraphs: list[PptParagraphStyle] | None = Field(
+        default=None,
+        alias="paragraphs",
+        description="Paragraph-level formatting (bullet), char-range addressed",
+    )
 
 
 class PptGetSlideInfoRequest(BaseRequest):
@@ -421,44 +539,48 @@ class PptUpdateTableRowColumnRequest(BaseRequest):
 
 class CellFormat(SocketIOBaseModel):
     """
-    Format for a specific table cell.
+    Format for a specific table cell (OASP 0.4.0). Font consolidated under ``font`` (PptFont, whole-cell;
+    no run-level). Alignment uses the office.js PowerPoint enums (7-value horizontal / 6-value vertical).
     """
 
     row_index: int = Field(..., alias="rowIndex", description="Row index (0-based)", ge=0)
     column_index: int = Field(..., alias="columnIndex", description="Column index (0-based)", ge=0)
     background_color: str | None = Field(default=None, alias="backgroundColor", description="Background color (hex)")
-    font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
-    font_color: str | None = Field(default=None, alias="fontColor", description="Font color (hex)")
-    bold: bool | None = Field(default=None, description="Bold text")
-    italic: bool | None = Field(default=None, description="Italic text")
-    horizontal_alignment: Literal["Left", "Center", "Right"] | None = Field(
-        default=None, alias="horizontalAlignment", description="Horizontal alignment"
+    font: PptFont | None = Field(
+        default=None, alias="font", description="Cell font formatting (whole cell; no run-level)"
     )
-    vertical_alignment: Literal["Top", "Middle", "Bottom"] | None = Field(
-        default=None, alias="verticalAlignment", description="Vertical alignment"
+    horizontal_alignment: ParagraphHorizontalAlignment | None = Field(
+        default=None, alias="horizontalAlignment", description="Horizontal alignment (7-value enum)"
+    )
+    vertical_alignment: TextVerticalAlignment | None = Field(
+        default=None, alias="verticalAlignment", description="Vertical alignment (6-value enum)"
     )
 
 
 class RowFormat(SocketIOBaseModel):
     """
-    Format for a table row.
+    Format for a table row (OASP 0.4.0). ``font`` / ``backgroundColor`` fan out per-cell; ``height`` is row-native.
     """
 
     row_index: int = Field(..., alias="rowIndex", description="Row index (0-based)", ge=0)
     height: float | None = Field(default=None, description="Row height (points)")
     background_color: str | None = Field(default=None, alias="backgroundColor", description="Background color (hex)")
-    font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
+    font: PptFont | None = Field(
+        default=None, alias="font", description="Font formatting (applied per-cell in the row)"
+    )
 
 
 class ColumnFormat(SocketIOBaseModel):
     """
-    Format for a table column.
+    Format for a table column (OASP 0.4.0). ``font`` / ``backgroundColor`` fan out per-cell; ``width`` is column-native.
     """
 
     column_index: int = Field(..., alias="columnIndex", description="Column index (0-based)", ge=0)
     width: float | None = Field(default=None, description="Column width (points)")
     background_color: str | None = Field(default=None, alias="backgroundColor", description="Background color (hex)")
-    font_size: int | None = Field(default=None, alias="fontSize", description="Font size")
+    font: PptFont | None = Field(
+        default=None, alias="font", description="Font formatting (applied per-cell in the column)"
+    )
 
 
 class PptUpdateTableFormatRequest(BaseRequest):

--- a/office4ai/environment/workspace/dtos/word.py
+++ b/office4ai/environment/workspace/dtos/word.py
@@ -592,81 +592,93 @@ class WordAppendTextRequest(BaseRequest):
     )
 
 
-class TextFormat(SocketIOBaseModel):
+# ============================================================================
+# Font abstraction (WordFont) — OASP 0.4.0
+# 字体属性收敛为 WordFont 子对象，TextFormat 与 CellFormat 复用。对齐 Word.js Word.Font。
+# ============================================================================
+
+# Word 下划线样式枚举（对齐 Word.js Word.UnderlineType，18 个可 SET 值，PascalCase）。
+# 排除仅回读的 "Mixed" 与已废弃的 "Hidden" / "DotLine"。
+UnderlineStyle = Literal[
+    "None",
+    "Single",
+    "Word",
+    "Double",
+    "Thick",
+    "Dotted",
+    "DottedHeavy",
+    "DashLine",
+    "DashLineHeavy",
+    "DashLineLong",
+    "DashLineLongHeavy",
+    "DotDashLine",
+    "DotDashLineHeavy",
+    "TwoDotDashLine",
+    "TwoDotDashLineHeavy",
+    "Wave",
+    "WaveHeavy",
+    "WaveDouble",
+]
+
+
+class WordFont(SocketIOBaseModel):
     """
-    Text formatting options.
+    Word 字体格式（OASP 0.4.0）。整段（TextFormat.font）与表格单元格（CellFormat.font）复用。
+    对齐 Word.js ``Word.Font``，双端零映射。所有字段可选，未提供的属性保持原样。
 
-    Uses Pydantic aliases for protocol compliance.
-
-    Confluence Spec: https://turingfocus.atlassian.net/wiki/pages/29753356/word+insert+text
-
-    Priority Rule (Important):
-        - Direct formatting (bold/italic/fontSize/etc) takes precedence over styleName
-        - If any direct format fields are provided, styleName is ignored
-        - If only styleName is provided, Word style is applied
-        - If neither is provided, default formatting is used
-
-    Examples:
-        # ❌ Not recommended: styleName will be ignored when direct format is present
-        format = {"bold": True, "style_name": "Heading 1"}  # Only bold takes effect
-
-        # ✅ Recommended: Use Word style only
-        format = {"style_name": "Heading 1"}  # Apply Heading 1 style
-
-        # ✅ Recommended: Use direct format only
-        format = {"bold": True, "color": "#FF0000"}  # Precise format control
+    版本门槛：文本字体 WordApi 1.1；用于表格单元格时经 cell.body.font 抬至 1.3。
     """
 
     bold: bool | None = Field(default=None, alias="bold", description="Bold text")
-    italic: bool | None = Field(
-        default=None,
-        alias="italic",
-        description="Italic text",
-    )
-    font_size: int | None = Field(
-        default=None,
-        alias="fontSize",
-        description="Font size",
-    )
-    font_name: str | None = Field(
-        default=None,
-        alias="fontName",
-        description="Font name",
-    )
-    color: str | None = Field(
-        default=None,
-        alias="color",
-        description="Font color (hex)",
-    )
-    underline: (
-        Literal[
-            "Mixed",
-            "None",
-            "Hidden",
-            "DotLine",
-            "Single",
-            "Word",
-            "Double",
-            "Thick",
-            "Dotted",
-            "DottedHeavy",
-            "DashLine",
-            "DashLineHeavy",
-            "DashLineLong",
-            "DashLineLongHeavy",
-            "DotDashLine",
-            "DotDashLineHeavy",
-            "TwoDotDashLine",
-            "TwoDotDashLineHeavy",
-            "Wave",
-            "WaveHeavy",
-            "WaveDouble",
-        ]
-        | None
-    ) = Field(
+    italic: bool | None = Field(default=None, alias="italic", description="Italic text")
+    underline: UnderlineStyle | None = Field(
         default=None,
         alias="underline",
-        description="Underline type (Word.UnderlineType)",
+        description="Underline style (Word.UnderlineType, PascalCase; 18 settable values)",
+    )
+    size: float | None = Field(
+        default=None,
+        alias="size",
+        description="Font size (points), positive number",
+        gt=0,
+    )
+    name: str | None = Field(default=None, alias="name", description="Font family name")
+    color: str | None = Field(default=None, alias="color", description="Font color (hex, e.g. '#FF0000')")
+    highlight_color: str | None = Field(
+        default=None,
+        alias="highlightColor",
+        description=(
+            "Highlight color: hex '#RRGGBB' or a Word preset name (e.g. 'Yellow'). "
+            "Desktop Word supports only 15 preset highlight colors; arbitrary RGB snaps to the "
+            "nearest preset — prefer preset names for precise control. Protocol allows null to "
+            "clear highlight, but this Server cannot emit explicit null (payloads use exclude_none)."
+        ),
+    )
+
+
+class TextFormat(SocketIOBaseModel):
+    """
+    Text formatting options (OASP 0.4.0).
+
+    Font attributes are consolidated under ``font`` (WordFont); ``styleName`` is an
+    independent concern.
+
+    Priority Rule (Important):
+        - When both ``font`` and ``styleName`` are provided, ``font`` takes precedence.
+        - Processing order: apply ``styleName`` first, then override with ``font``.
+
+    Examples:
+        # Word style only
+        format = {"style_name": "Heading 1"}
+
+        # Direct font only
+        format = {"font": {"bold": True, "color": "#FF0000"}}
+    """
+
+    font: Optional["WordFont"] = Field(
+        default=None,
+        alias="font",
+        description="Font formatting (see WordFont)",
     )
     style_name: str | None = Field(
         default=None,
@@ -1363,24 +1375,11 @@ class CellFormat(SocketIOBaseModel):
         alias="backgroundColor",
         description="Cell background color (hex, e.g. '#1F4E79')",
     )
-    font_name: str | None = Field(
+    font: Optional["WordFont"] = Field(
         default=None,
-        alias="fontName",
-        description="Font family name",
+        alias="font",
+        description="Cell font formatting (WordFont; applied to entire cell body, overrides paragraph/run fonts)",
     )
-    font_size: float | None = Field(
-        default=None,
-        alias="fontSize",
-        description="Font size (points), positive number",
-        gt=0,
-    )
-    font_color: str | None = Field(
-        default=None,
-        alias="fontColor",
-        description="Font color (hex)",
-    )
-    bold: bool | None = Field(default=None, alias="bold", description="Bold text")
-    italic: bool | None = Field(default=None, alias="italic", description="Italic text")
 
 
 class TableSummary(SocketIOBaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office4ai"
-version = "0.3.0"
+version = "0.4.0"
 description = "A powerful Office document management environment designed for AI agents to interact with Office documents"
 readme = "README.md"
 authors = [

--- a/tests/contract_tests/ppt/test_insert_text.py
+++ b/tests/contract_tests/ppt/test_insert_text.py
@@ -79,17 +79,17 @@ async def test_insert_text_with_options(
         "top": 200.0,
         "width": 300.0,
         "height": 50.0,
-        "fontSize": 24,
-        "fontName": "Arial",
-        "color": "#FF0000",
+        "font": {"size": 24, "name": "Arial", "color": "#FF0000", "strikethrough": True},
     }
 
     def response_factory(request: dict) -> dict:
         assert "options" in request
         opts = request["options"]
         assert opts["slideIndex"] == 2
-        assert opts["fontSize"] == 24
-        assert opts["color"] == "#FF0000"
+        # OASP 0.4.0: 插入即带字体，字体收敛到 font 子对象
+        assert opts["font"]["size"] == 24
+        assert opts["font"]["color"] == "#FF0000"
+        assert opts["font"]["strikethrough"] is True
 
         return {
             "requestId": request["requestId"],

--- a/tests/contract_tests/ppt/test_update_table_format.py
+++ b/tests/contract_tests/ppt/test_update_table_format.py
@@ -27,8 +27,9 @@ async def test_update_table_format_cell_formats(
             "rowIndex": 0,
             "columnIndex": 0,
             "backgroundColor": "#FF0000",
-            "bold": True,
-            "fontSize": 14,
+            "font": {"bold": True, "size": 14, "underline": "Single"},
+            "horizontalAlignment": "Center",
+            "verticalAlignment": "Middle",
         },
     ]
 
@@ -37,7 +38,13 @@ async def test_update_table_format_cell_formats(
         assert len(request["cellFormats"]) == 1
         fmt = request["cellFormats"][0]
         assert fmt["backgroundColor"] == "#FF0000"
-        assert fmt["bold"] is True
+        # OASP 0.4.0: 字体收敛到 font 子对象
+        assert fmt["font"]["bold"] is True
+        assert fmt["font"]["size"] == 14
+        assert fmt["font"]["underline"] == "Single"
+        # 对齐改用 office.js PowerPoint 枚举（Center/Middle）
+        assert fmt["horizontalAlignment"] == "Center"
+        assert fmt["verticalAlignment"] == "Middle"
 
         return {
             "requestId": request["requestId"],
@@ -87,12 +94,15 @@ async def test_update_table_format_row_formats(
 ):
     """测试行级别格式更新。"""
     row_formats = [
-        {"rowIndex": 0, "height": 50.0, "backgroundColor": "#EEEEEE", "fontSize": 16},
+        {"rowIndex": 0, "height": 50.0, "backgroundColor": "#EEEEEE", "font": {"size": 16, "bold": True}},
     ]
 
     def response_factory(request: dict) -> dict:
         assert len(request["rowFormats"]) == 1
         assert request["rowFormats"][0]["height"] == 50.0
+        # OASP 0.4.0: 行级字体升级为完整 PptFont（原仅 fontSize）
+        assert request["rowFormats"][0]["font"]["size"] == 16
+        assert request["rowFormats"][0]["font"]["bold"] is True
 
         return {
             "requestId": request["requestId"],
@@ -138,12 +148,14 @@ async def test_update_table_format_column_formats(
     """测试列级别格式更新。"""
     column_formats = [
         {"columnIndex": 0, "width": 150.0, "backgroundColor": "#DDDDDD"},
-        {"columnIndex": 1, "width": 200.0, "fontSize": 12},
+        {"columnIndex": 1, "width": 200.0, "font": {"size": 12}},
     ]
 
     def response_factory(request: dict) -> dict:
         assert len(request["columnFormats"]) == 2
         assert request["columnFormats"][0]["width"] == 150.0
+        # OASP 0.4.0: 列级字体升级为完整 PptFont（原仅 fontSize）
+        assert request["columnFormats"][1]["font"]["size"] == 12
 
         return {
             "requestId": request["requestId"],
@@ -212,7 +224,7 @@ async def test_update_table_format_error(
             params={
                 "document_uri": client.document_uri,
                 "elementId": "nonexistent",
-                "cellFormats": [{"rowIndex": 0, "columnIndex": 0, "bold": True}],
+                "cellFormats": [{"rowIndex": 0, "columnIndex": 0, "font": {"bold": True}}],
             },
         )
         result = await workspace.execute(action)

--- a/tests/contract_tests/ppt/test_update_text_box.py
+++ b/tests/contract_tests/ppt/test_update_text_box.py
@@ -80,9 +80,19 @@ async def test_update_text_box_text_and_style(
     def response_factory(request: dict) -> dict:
         updates = request["updates"]
         assert updates["text"] == "Bold Title"
-        assert updates["fontSize"] == 32
-        assert updates["bold"] is True
-        assert updates["color"] == "#FF0000"
+        # OASP 0.4.0: 字体收敛到 font 子对象
+        assert updates["font"]["size"] == 32
+        assert updates["font"]["bold"] is True
+        assert updates["font"]["color"] == "#FF0000"
+        assert updates["font"]["underline"] == "WavyHeavy"
+        assert updates["fillColor"] == "#EEEEEE"
+        # run 级局部格式 + 段落 bullet（嵌套区间寻址）
+        assert updates["runs"][0] == {"start": 0, "length": 4, "font": {"color": "#C00000", "allCaps": True}}
+        assert updates["paragraphs"][0]["bulletFormat"] == {
+            "visible": True,
+            "type": "Numbered",
+            "style": "ArabicNumeralPeriod",
+        }
 
         return {
             "requestId": request["requestId"],
@@ -110,12 +120,23 @@ async def test_update_text_box_text_and_style(
                 "elementId": "shape-001",
                 "updates": {
                     "text": "Bold Title",
-                    "fontSize": 32,
-                    "fontName": "Arial",
-                    "color": "#FF0000",
-                    "bold": True,
-                    "italic": False,
+                    "font": {
+                        "size": 32,
+                        "name": "Arial",
+                        "color": "#FF0000",
+                        "bold": True,
+                        "italic": False,
+                        "underline": "WavyHeavy",
+                    },
                     "fillColor": "#EEEEEE",
+                    "runs": [{"start": 0, "length": 4, "font": {"color": "#C00000", "allCaps": True}}],
+                    "paragraphs": [
+                        {
+                            "start": 0,
+                            "length": 20,
+                            "bulletFormat": {"visible": True, "type": "Numbered", "style": "ArabicNumeralPeriod"},
+                        }
+                    ],
                 },
             },
         )

--- a/tests/contract_tests/word/test_replace_text.py
+++ b/tests/contract_tests/word/test_replace_text.py
@@ -244,21 +244,20 @@ async def test_replace_text_with_format(
     4. Workspace 发送带 format 的 word:replace:text 命令
     5. 验证 format 数据正确传递到 Mock 客户端
     """
-    # Arrange
+    # Arrange (OASP 0.4.0: 字体收敛到 format.font = WordFont)
     expected_format = {
-        "bold": True,
-        "color": "#FF0000",
-        "fontSize": 16,
+        "font": {"bold": True, "color": "#FF0000", "size": 16, "underline": "Single"},
     }
 
     def response_with_format_validation(request: dict) -> dict:
         """验证 format 字段的响应工厂"""
         # 验证 format 正确传递
         assert "format" in request, "format field should be present in request"
-        actual_format = request["format"]
-        assert actual_format["bold"] is True
-        assert actual_format["color"] == "#FF0000"
-        assert actual_format["fontSize"] == 16
+        actual_font = request["format"]["font"]
+        assert actual_font["bold"] is True
+        assert actual_font["color"] == "#FF0000"
+        assert actual_font["size"] == 16
+        assert actual_font["underline"] == "Single"
 
         return {
             "requestId": request["requestId"],
@@ -302,8 +301,8 @@ async def test_replace_text_with_format(
         assert event_name == "word:replace:text"
         assert event_data["searchText"] == "important"
         assert event_data["replaceText"] == "important"
-        assert event_data["format"]["bold"] is True
-        assert event_data["format"]["color"] == "#FF0000"
+        assert event_data["format"]["font"]["bold"] is True
+        assert event_data["format"]["font"]["color"] == "#FF0000"
     finally:
         await client.disconnect()
 

--- a/tests/contract_tests/word/test_update_table_cell.py
+++ b/tests/contract_tests/word/test_update_table_cell.py
@@ -35,8 +35,10 @@ async def test_update_table_cell_with_format(
         assert fmt["horizontalAlignment"] == "Centered"
         assert fmt["verticalAlignment"] == "Center"
         assert fmt["backgroundColor"] == "#1F4E79"
-        assert fmt["fontColor"] == "#FFFFFF"
-        assert fmt["bold"] is True
+        # OASP 0.4.0: 字体收敛到 font 子对象（WordFont）
+        assert fmt["font"]["color"] == "#FFFFFF"
+        assert fmt["font"]["bold"] is True
+        assert fmt["font"]["underline"] == "Single"
 
         return {
             "requestId": request["requestId"],
@@ -73,8 +75,7 @@ async def test_update_table_cell_with_format(
                             "horizontalAlignment": "Centered",
                             "verticalAlignment": "Center",
                             "backgroundColor": "#1F4E79",
-                            "fontColor": "#FFFFFF",
-                            "bold": True,
+                            "font": {"color": "#FFFFFF", "bold": True, "underline": "Single"},
                         },
                     }
                 ],
@@ -137,14 +138,14 @@ async def test_update_table_cell_batch(
                         "rowIndex": 1,
                         "columnIndex": 0,
                         "text": "甲方",
-                        "format": {"backgroundColor": "#EEEEEE", "bold": True},
+                        "format": {"backgroundColor": "#EEEEEE", "font": {"bold": True}},
                     },
                     {"rowIndex": 1, "columnIndex": 1, "text": "ACME Corp"},
                     {
                         "rowIndex": 2,
                         "columnIndex": 0,
                         "text": "地址",
-                        "format": {"backgroundColor": "#EEEEEE", "bold": True},
+                        "format": {"backgroundColor": "#EEEEEE", "font": {"bold": True}},
                     },
                     {"rowIndex": 2, "columnIndex": 1, "text": "上海市"},
                 ],

--- a/tests/integration_tests/office4ai/environment/workspace/socketio/conftest.py
+++ b/tests/integration_tests/office4ai/environment/workspace/socketio/conftest.py
@@ -15,6 +15,7 @@ from socketio import AsyncClient, AsyncServer  # type: ignore[import-untyped]
 
 from office4ai.environment.workspace.socketio.config import SocketIOConfig
 from office4ai.environment.workspace.socketio.server import create_socketio_server
+from office4ai.environment.workspace.socketio.versioning import SERVER_VERSION
 
 
 @pytest_asyncio.fixture
@@ -53,7 +54,7 @@ async def socketio_server() -> AsyncServer:
 INTEGRATION_AUTH: dict[str, Any] = {
     "clientId": "integration_test_client",
     "documentUri": "file:///tmp/integration_test.docx",
-    "oaspVersion": "0.3.0",
+    "oaspVersion": str(SERVER_VERSION),  # 同 Server 版本，随 bump 自动跟随
 }
 
 

--- a/tests/integration_tests/office4ai/environment/workspace/socketio/test_client_connection.py
+++ b/tests/integration_tests/office4ai/environment/workspace/socketio/test_client_connection.py
@@ -7,11 +7,13 @@ Test client connection flow
 import pytest
 from socketio import AsyncClient  # type: ignore[import-untyped]
 
+from office4ai.environment.workspace.socketio.versioning import SERVER_VERSION
+
 # OASP 0.3.0 起握手强制校验 oaspVersion（version-first），客户端必须注入同 MAJOR.MINOR 版本
 INTEGRATION_AUTH = {
     "clientId": "integration_test_client",
     "documentUri": "file:///tmp/integration_test.docx",
-    "oaspVersion": "0.3.0",
+    "oaspVersion": str(SERVER_VERSION),  # 同 Server 版本，随 bump 自动跟随
 }
 
 

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/ppt/test_ppt_tools.py
@@ -11,6 +11,7 @@ PPT MCP Tools 单元测试 | PPT MCP Tools unit tests
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from office4ai.a2c_smcp.tools.ppt import (
     PptAddSlideTool,
@@ -229,7 +230,7 @@ class TestExecuteFlow:
             {
                 "document_uri": "file:///test.pptx",
                 "text": "Hello PPT",
-                "options": {"slideIndex": 0, "left": 100, "top": 200, "fontSize": 18},
+                "options": {"slideIndex": 0, "left": 100, "top": 200, "font": {"size": 18}},
             }
         )
 
@@ -238,6 +239,8 @@ class TestExecuteFlow:
         assert action.action_name == "insert:text"
         assert action.params["text"] == "Hello PPT"
         assert action.params["options"]["slide_index"] == 0
+        # font attributes consolidated under the nested font sub-object (OASP 0.4.0)
+        assert action.params["options"]["font"]["size"] == 18
 
     @pytest.mark.asyncio
     async def test_insert_image_action(self, mock_workspace):
@@ -312,7 +315,7 @@ class TestExecuteFlow:
             {
                 "document_uri": "file:///test.pptx",
                 "elementId": "shape-001",
-                "updates": {"text": "Updated title", "fontSize": 28, "bold": True},
+                "updates": {"text": "Updated title", "font": {"size": 28, "bold": True}},
             }
         )
 
@@ -321,7 +324,9 @@ class TestExecuteFlow:
         assert action.action_name == "update:textBox"
         assert action.params["elementId"] == "shape-001"
         assert action.params["updates"]["text"] == "Updated title"
-        assert action.params["updates"]["bold"] is True
+        # font attributes consolidated under the nested font sub-object (OASP 0.4.0)
+        assert action.params["updates"]["font"]["bold"] is True
+        assert action.params["updates"]["font"]["size"] == 28
 
     @pytest.mark.asyncio
     async def test_update_image_action(self, mock_workspace):
@@ -402,8 +407,16 @@ class TestExecuteFlow:
             {
                 "document_uri": "file:///test.pptx",
                 "elementId": "shape-030",
-                "rowFormats": [{"rowIndex": 0, "backgroundColor": "#4472C4", "fontSize": 14}],
-                "cellFormats": [{"rowIndex": 1, "columnIndex": 0, "bold": True, "fontColor": "#333333"}],
+                "rowFormats": [{"rowIndex": 0, "backgroundColor": "#4472C4", "font": {"size": 14}}],
+                "cellFormats": [
+                    {
+                        "rowIndex": 1,
+                        "columnIndex": 0,
+                        "font": {"bold": True, "color": "#333333"},
+                        "horizontalAlignment": "Center",
+                        "verticalAlignment": "Middle",
+                    }
+                ],
             }
         )
 
@@ -413,6 +426,14 @@ class TestExecuteFlow:
         assert action.params["elementId"] == "shape-030"
         assert len(action.params["rowFormats"]) == 1
         assert len(action.params["cellFormats"]) == 1
+        # font attributes consolidated under nested font sub-object (OASP 0.4.0)
+        assert action.params["rowFormats"][0]["font"]["size"] == 14
+        cell_fmt = action.params["cellFormats"][0]
+        assert cell_fmt["font"]["bold"] is True
+        assert cell_fmt["font"]["color"] == "#333333"
+        # PPT table alignment uses the office.js PowerPoint enums (Center / Middle)
+        assert cell_fmt["horizontal_alignment"] == "Center"
+        assert cell_fmt["vertical_alignment"] == "Middle"
 
     @pytest.mark.asyncio
     async def test_update_element_action(self, mock_workspace):
@@ -979,7 +1000,7 @@ class TestElementIdIntCoercion:
             (PptReorderElementTool, {"action": "bringToFront"}),
             (PptUpdateTableCellTool, {"cells": [{"rowIndex": 0, "columnIndex": 0, "text": "A"}]}),
             (PptUpdateTableRowColumnTool, {"rows": [{"rowIndex": 0, "values": ["A"]}]}),
-            (PptUpdateTableFormatTool, {"rowFormats": [{"rowIndex": 0, "bold": True}]}),
+            (PptUpdateTableFormatTool, {"rowFormats": [{"rowIndex": 0, "font": {"bold": True}}]}),
         ],
     )
     async def test_all_tools_int_element_id(self, mock_workspace, tool_cls, extra_params):
@@ -1709,3 +1730,169 @@ class TestMcpContentMapping:
         blocks = tool.to_mcp_content(result)
 
         assert blocks == [{"type": "text", "text": str(result)}]
+
+
+# ============================================================================
+# OASP 0.4.0 font abstraction — DTO wire-shape coverage (PptFont / runs / paragraphs)
+# ============================================================================
+# The nested font sub-object is the authoritative wire form (model_dump(by_alias=True)).
+# These assert the new capabilities the 0.4.0 refactor introduced on the /ppt DTOs.
+
+
+class TestPptFontWireShape:
+    """PptFont (OASP 0.4.0) — nested font sub-object wire round-trip."""
+
+    def test_extended_effect_flags_round_trip(self) -> None:
+        """New capability: strikethrough/doubleStrikethrough/superscript/subscript/allCaps/smallCaps [1.8]."""
+        from office4ai.environment.workspace.dtos.ppt import PptFont
+
+        font = PptFont(
+            size=18,
+            name="Calibri",
+            color="#333333",
+            bold=True,
+            italic=False,
+            underline="Single",
+            strikethrough=True,
+            double_strikethrough=True,
+            superscript=False,
+            subscript=True,
+            all_caps=True,
+            small_caps=False,
+        )
+
+        data = font.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["size"] == 18
+        assert data["name"] == "Calibri"
+        assert data["color"] == "#333333"
+        assert data["bold"] is True
+        assert data["italic"] is False
+        assert data["underline"] == "Single"
+        # extended effect flags surface with camelCase aliases on the wire
+        assert data["strikethrough"] is True
+        assert data["doubleStrikethrough"] is True
+        assert data["superscript"] is False
+        assert data["subscript"] is True
+        assert data["allCaps"] is True
+        assert data["smallCaps"] is False
+
+    def test_camelcase_input_populates_snake_case_fields(self) -> None:
+        """populate_by_name: camelCase wire keys map onto snake_case Python fields."""
+        from office4ai.environment.workspace.dtos.ppt import PptFont
+
+        font = PptFont(**{"doubleStrikethrough": True, "allCaps": True, "smallCaps": True})
+
+        assert font.double_strikethrough is True
+        assert font.all_caps is True
+        assert font.small_caps is True
+
+    def test_half_point_size_accepted(self) -> None:
+        """size 为 number（float），接受半磅字号（PowerPoint 常见 10.5 / 7.5pt），与 WordFont.size 一致。"""
+        from office4ai.environment.workspace.dtos.ppt import PptFont
+
+        font = PptFont(size=10.5)
+        assert font.size == 10.5
+        assert font.model_dump(by_alias=True, exclude_none=True)["size"] == 10.5
+
+    def test_non_positive_size_rejected(self) -> None:
+        """size 必须为正（gt=0），与 WordFont.size 对齐。"""
+        from office4ai.environment.workspace.dtos.ppt import PptFont
+
+        with pytest.raises(ValidationError):
+            PptFont(size=0)
+        with pytest.raises(ValidationError):
+            PptFont(size=-1)
+
+
+class TestTextBoxUpdatesWireShape:
+    """TextBoxUpdates (OASP 0.4.0) — whole-box font + run-level + paragraph bullet nested wire."""
+
+    def test_runs_and_paragraphs_nested_wire(self) -> None:
+        """New capability: runs[] (PptTextRun) + paragraphs[] (bulletFormat visible/type/style)."""
+        from office4ai.environment.workspace.dtos.ppt import (
+            BulletFormat,
+            PptFont,
+            PptParagraphStyle,
+            PptTextRun,
+            TextBoxUpdates,
+        )
+
+        updates = TextBoxUpdates(
+            text="Agenda",
+            fillColor="#FFFFFF",
+            font=PptFont(size=20, bold=True),
+            runs=[PptTextRun(start=0, length=6, font=PptFont(color="#FF0000", italic=True))],
+            paragraphs=[
+                PptParagraphStyle(
+                    start=0,
+                    length=6,
+                    bulletFormat=BulletFormat(visible=True, type="Numbered", style="ArabicNumeralPeriod"),
+                )
+            ],
+        )
+
+        data = updates.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["text"] == "Agenda"
+        assert data["fillColor"] == "#FFFFFF"
+        # whole-box base-layer font
+        assert data["font"] == {"size": 20, "bold": True}
+        # run-level local formatting
+        assert data["runs"][0]["start"] == 0
+        assert data["runs"][0]["length"] == 6
+        assert data["runs"][0]["font"] == {"color": "#FF0000", "italic": True}
+        # paragraph-level bullet formatting (bullet_type aliases to "type" on the wire)
+        para = data["paragraphs"][0]
+        assert para["start"] == 0
+        assert para["length"] == 6
+        assert para["bulletFormat"] == {"visible": True, "type": "Numbered", "style": "ArabicNumeralPeriod"}
+
+    def test_run_indices_reject_negative(self) -> None:
+        """PptTextRun start/length carry ge=0 constraints."""
+        from office4ai.environment.workspace.dtos.ppt import PptFont, PptTextRun
+
+        with pytest.raises(ValidationError):
+            PptTextRun(start=-1, length=3, font=PptFont(bold=True))
+
+
+class TestPptTableCellFormatWireShape:
+    """PPT tableFormat CellFormat (OASP 0.4.0) — nested font + office.js PowerPoint alignment enums."""
+
+    def test_new_alignment_enums_and_nested_font(self) -> None:
+        """New capability: horizontalAlignment='Center' / verticalAlignment='Middle' + font sub-object."""
+        from office4ai.environment.workspace.dtos.ppt import CellFormat, PptFont
+
+        fmt = CellFormat(
+            rowIndex=1,
+            columnIndex=0,
+            backgroundColor="#4472C4",
+            font=PptFont(bold=True, color="#FFFFFF"),
+            horizontalAlignment="Center",
+            verticalAlignment="Middle",
+        )
+
+        data = fmt.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["rowIndex"] == 1
+        assert data["columnIndex"] == 0
+        assert data["backgroundColor"] == "#4472C4"
+        assert data["font"] == {"bold": True, "color": "#FFFFFF"}
+        # PPT uses Center (not Centered) / Middle (not Center) per office.js enums
+        assert data["horizontalAlignment"] == "Center"
+        assert data["verticalAlignment"] == "Middle"
+
+    def test_row_and_column_format_nested_font(self) -> None:
+        """RowFormat / ColumnFormat carry the nested font (fontSize removed in 0.4.0)."""
+        from office4ai.environment.workspace.dtos.ppt import ColumnFormat, PptFont, RowFormat
+
+        row = RowFormat(rowIndex=0, height=30, backgroundColor="#EEEEEE", font=PptFont(size=14))
+        col = ColumnFormat(columnIndex=2, width=120, font=PptFont(size=12, bold=True))
+
+        row_data = row.model_dump(by_alias=True, exclude_none=True)
+        col_data = col.model_dump(by_alias=True, exclude_none=True)
+
+        assert row_data["font"] == {"size": 14}
+        assert row_data["height"] == 30
+        assert col_data["font"] == {"size": 12, "bold": True}
+        assert col_data["width"] == 120

--- a/tests/unit_tests/office4ai/a2c_smcp/tools/word/test_word_tools.py
+++ b/tests/unit_tests/office4ai/a2c_smcp/tools/word/test_word_tools.py
@@ -151,14 +151,14 @@ class TestExecuteFlow:
             {
                 "document_uri": "file:///test.docx",
                 "text": "Bold Text",
-                "format": {"bold": True, "font_size": 14},
+                "format": {"font": {"bold": True, "size": 14}},
             }
         )
 
         action = mock_workspace.execute.call_args[0][0]
         assert action.params["text"] == "Bold Text"
-        assert action.params["format"]["bold"] is True
-        assert action.params["format"]["font_size"] == 14
+        assert action.params["format"]["font"]["bold"] is True
+        assert action.params["format"]["font"]["size"] == 14
 
     @pytest.mark.asyncio
     async def test_append_text_builds_correct_action(self, mock_workspace):
@@ -213,7 +213,7 @@ class TestExecuteFlow:
                 "document_uri": "file:///test.docx",
                 "search_text": "important",
                 "replace_text": "important",
-                "format": {"bold": True, "color": "#FF0000", "font_size": 16},
+                "format": {"font": {"bold": True, "color": "#FF0000", "size": 16}},
                 "options": {"replace_all": True},
             }
         )
@@ -223,9 +223,9 @@ class TestExecuteFlow:
         assert action.action_name == "replace:text"
         assert action.params["search_text"] == "important"
         assert action.params["replace_text"] == "important"
-        assert action.params["format"]["bold"] is True
-        assert action.params["format"]["color"] == "#FF0000"
-        assert action.params["format"]["font_size"] == 16
+        assert action.params["format"]["font"]["bold"] is True
+        assert action.params["format"]["font"]["color"] == "#FF0000"
+        assert action.params["format"]["font"]["size"] == 16
         assert result["success"] is True
 
     @pytest.mark.asyncio
@@ -458,7 +458,7 @@ class TestExecuteFlow:
         result = await tool.execute(
             {
                 "document_uri": "file:///test.docx",
-                "content": {"text": "Replacement text", "format": {"bold": True}},
+                "content": {"text": "Replacement text", "format": {"font": {"bold": True}}},
             }
         )
 
@@ -466,6 +466,7 @@ class TestExecuteFlow:
         assert action.category == "word"
         assert action.action_name == "replace:selection"
         assert action.params["content"]["text"] == "Replacement text"
+        assert action.params["content"]["format"]["font"]["bold"] is True
         assert result["success"] is True
 
     @pytest.mark.asyncio
@@ -1213,8 +1214,7 @@ class TestWordUpdateTableCellTool:
                             "horizontalAlignment": "Centered",
                             "verticalAlignment": "Center",
                             "backgroundColor": "#1F4E79",
-                            "fontColor": "#FFFFFF",
-                            "bold": True,
+                            "font": {"color": "#FFFFFF", "bold": True},
                         },
                     }
                 ],
@@ -1230,7 +1230,9 @@ class TestWordUpdateTableCellTool:
         # snake_case is expected internally because DTO field names are snake_case
         assert cell["format"]["horizontal_alignment"] == "Centered"
         assert cell["format"]["background_color"] == "#1F4E79"
-        assert cell["format"]["bold"] is True
+        # font attributes consolidated under the nested font sub-object (OASP 0.4.0)
+        assert cell["format"]["font"]["color"] == "#FFFFFF"
+        assert cell["format"]["font"]["bold"] is True
         assert result["success"] is True
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/office4ai/environment/workspace/dtos/test_replace_text_dtos.py
+++ b/tests/unit_tests/office4ai/environment/workspace/dtos/test_replace_text_dtos.py
@@ -14,6 +14,7 @@ from office4ai.environment.workspace.dtos.word import (
     ReplaceOptions,
     ReplaceTextResult,
     TextFormat,
+    WordFont,
     WordReplaceTextRequest,
     WordReplaceTextResponse,
 )
@@ -183,8 +184,8 @@ class TestWordReplaceTextRequest:
         assert request.replace_text == "replaced"
 
     def test_valid_request_with_format(self) -> None:
-        """Test creating valid request with text formatting"""
-        fmt = TextFormat(bold=True, italic=False, fontSize=14, color="#FF0000")
+        """Test creating valid request with nested-font text formatting"""
+        fmt = TextFormat(font=WordFont(bold=True, italic=False, size=14, color="#FF0000"))
 
         request = WordReplaceTextRequest(
             requestId="req_010",
@@ -195,14 +196,15 @@ class TestWordReplaceTextRequest:
         )
 
         assert request.format is not None
-        assert request.format.bold is True
-        assert request.format.italic is False
-        assert request.format.font_size == 14
-        assert request.format.color == "#FF0000"
+        assert request.format.font is not None
+        assert request.format.font.bold is True
+        assert request.format.font.italic is False
+        assert request.format.font.size == 14
+        assert request.format.font.color == "#FF0000"
 
     def test_request_with_format_serialization(self) -> None:
-        """Test format field serializes to camelCase payload"""
-        fmt = TextFormat(bold=True, styleName="Heading 1")
+        """Test nested font + styleName serialize to camelCase payload"""
+        fmt = TextFormat(font=WordFont(bold=True), styleName="Heading 1")
 
         request = WordReplaceTextRequest(
             requestId="req_011",
@@ -214,7 +216,7 @@ class TestWordReplaceTextRequest:
 
         payload = request.to_payload()
 
-        assert payload["format"]["bold"] is True
+        assert payload["format"]["font"]["bold"] is True
         assert payload["format"]["styleName"] == "Heading 1"
 
     def test_request_without_format(self) -> None:

--- a/tests/unit_tests/office4ai/environment/workspace/dtos/test_word_dtos.py
+++ b/tests/unit_tests/office4ai/environment/workspace/dtos/test_word_dtos.py
@@ -38,6 +38,7 @@ from office4ai.environment.workspace.dtos.word import (
     TableSummary,
     TextFormat,
     WordDeleteCommentRequest,
+    WordFont,
     WordGetCommentsRequest,
     WordGetCommentsResponse,
     WordGetDocumentStatsRequest,
@@ -496,13 +497,15 @@ class TestWordInsertTextRequest:
         assert request_cursor.location == "Cursor"
 
     def test_valid_request_with_format(self) -> None:
-        """Test creating valid request with text format"""
+        """Test creating valid request with text format (nested font, OASP 0.4.0)"""
         format_options = TextFormat(
-            bold=True,
-            italic=False,
-            fontSize=14,
-            fontName="Arial",
-            color="#FF0000",
+            font=WordFont(
+                bold=True,
+                italic=False,
+                size=14,
+                name="Arial",
+                color="#FF0000",
+            )
         )
 
         request = WordInsertTextRequest(
@@ -515,25 +518,27 @@ class TestWordInsertTextRequest:
 
         assert request.text == "Formatted text"
         assert request.format is not None
-        assert request.format.bold is True
-        assert request.format.italic is False
-        assert request.format.font_size == 14
-        assert request.format.font_name == "Arial"
-        assert request.format.color == "#FF0000"
+        assert request.format.font is not None
+        assert request.format.font.bold is True
+        assert request.format.font.italic is False
+        assert request.format.font.size == 14
+        assert request.format.font.name == "Arial"
+        assert request.format.font.color == "#FF0000"
 
     def test_request_with_dict_format(self) -> None:
-        """Test creating request with format as dict"""
+        """Test creating request with nested font format as dict"""
         request = WordInsertTextRequest(
             requestId="req_006",
             documentUri="file:///test.docx",
             text="Text with format",
-            format={"bold": True, "italic": True, "fontSize": 12},
+            format={"font": {"bold": True, "italic": True, "size": 12}},
         )
 
         assert request.format is not None
-        assert request.format.bold is True
-        assert request.format.italic is True
-        assert request.format.font_size == 12
+        assert request.format.font is not None
+        assert request.format.font.bold is True
+        assert request.format.font.italic is True
+        assert request.format.font.size == 12
 
     def test_missing_required_fields(self) -> None:
         """Test validation fails without required fields"""
@@ -587,7 +592,7 @@ class TestWordInsertTextRequest:
             documentUri="file:///test.docx",
             text="Hello",
             location="Start",
-            format={"bold": True},
+            format={"font": {"bold": True}},
         )
 
         payload = request.to_payload()
@@ -596,7 +601,7 @@ class TestWordInsertTextRequest:
         assert payload["documentUri"] == "file:///test.docx"
         assert payload["text"] == "Hello"
         assert payload["location"] == "Start"
-        assert payload["format"]["bold"] is True
+        assert payload["format"]["font"]["bold"] is True
         assert isinstance(payload["timestamp"], int)
 
     def test_build_class_method(self) -> None:
@@ -615,131 +620,207 @@ class TestWordInsertTextRequest:
 
 
 class TestTextFormat:
-    """Test TextFormat DTO"""
+    """Test TextFormat DTO (OASP 0.4.0: nested font sub-object + styleName)"""
 
     def test_default_format(self) -> None:
         """Test creating format with default values"""
         format_options = TextFormat()
 
-        assert format_options.bold is None
-        assert format_options.italic is None
-        assert format_options.font_size is None
-        assert format_options.font_name is None
-        assert format_options.color is None
-        assert format_options.underline is None
+        assert format_options.font is None
         assert format_options.style_name is None
 
     def test_custom_format(self) -> None:
-        """Test creating format with custom values"""
+        """Test creating format with a nested font sub-object + styleName"""
         format_options = TextFormat(
-            bold=True,
-            italic=True,
-            fontSize=16,
-            fontName="Times New Roman",
-            color="#0000FF",
-            underline="Single",
+            font=WordFont(
+                bold=True,
+                italic=True,
+                size=16,
+                name="Times New Roman",
+                color="#0000FF",
+                underline="Single",
+            ),
             styleName="Heading 1",
         )
 
-        assert format_options.bold is True
-        assert format_options.italic is True
-        assert format_options.font_size == 16
-        assert format_options.font_name == "Times New Roman"
-        assert format_options.color == "#0000FF"
-        assert format_options.underline == "Single"
+        assert format_options.font is not None
+        assert format_options.font.bold is True
+        assert format_options.font.italic is True
+        assert format_options.font.size == 16
+        assert format_options.font.name == "Times New Roman"
+        assert format_options.font.color == "#0000FF"
+        assert format_options.font.underline == "Single"
         assert format_options.style_name == "Heading 1"
 
     def test_partial_format(self) -> None:
-        """Test creating format with partial fields"""
-        format_options = TextFormat(bold=True, fontSize=14)
+        """Test creating format with a partially-populated font"""
+        format_options = TextFormat(font=WordFont(bold=True, size=14))
 
-        assert format_options.bold is True
-        assert format_options.italic is None
-        assert format_options.font_size == 14
-        assert format_options.font_name is None
+        assert format_options.font is not None
+        assert format_options.font.bold is True
+        assert format_options.font.italic is None
+        assert format_options.font.size == 14
+        assert format_options.font.name is None
 
     def test_format_with_underline_types(self) -> None:
-        """Test different underline types"""
+        """Test different underline types carried on the nested font"""
         # Single underline
-        format_single = TextFormat(underline="Single")
-        assert format_single.underline == "Single"
+        format_single = TextFormat(font=WordFont(underline="Single"))
+        assert format_single.font.underline == "Single"
 
         # Double underline
-        format_double = TextFormat(underline="Double")
-        assert format_double.underline == "Double"
+        format_double = TextFormat(font=WordFont(underline="Double"))
+        assert format_double.font.underline == "Double"
 
         # Dotted underline
-        format_dotted = TextFormat(underline="Dotted")
-        assert format_dotted.underline == "Dotted"
+        format_dotted = TextFormat(font=WordFont(underline="Dotted"))
+        assert format_dotted.font.underline == "Dotted"
 
     def test_format_with_style_name_only(self) -> None:
         """Test format with only style name (recommended approach)"""
         format_options = TextFormat(styleName="Title")
 
         assert format_options.style_name == "Title"
-        # All direct format fields should be None
-        assert format_options.bold is None
-        assert format_options.italic is None
-        assert format_options.font_size is None
+        # font sub-object should be absent
+        assert format_options.font is None
 
-    def test_format_priority_rule_direct_format(self) -> None:
+    def test_format_priority_rule_direct_font(self) -> None:
         """
-        Test that direct format takes precedence over styleName.
+        Test that a direct font can coexist with styleName.
 
         Note: This is a documentation test - actual priority enforcement
-        happens in the Add-In implementation, not in the DTO.
+        (font overrides styleName) happens in the Add-In implementation, not the DTO.
         """
-        # Not recommended: styleName will be ignored when direct format is present
+        # Not recommended: styleName will be overridden when a direct font is present
         format_options = TextFormat(
-            bold=True,
+            font=WordFont(bold=True),
             styleName="Heading 1",
         )
 
-        assert format_options.bold is True
+        assert format_options.font is not None
+        assert format_options.font.bold is True
         assert format_options.style_name == "Heading 1"
-        # The Add-In should ignore styleName when bold is present
+        # The Add-In should override styleName with the font when both are present
 
     def test_format_serialization(self) -> None:
-        """Test format can be serialized to dict with correct aliases"""
+        """Test format serializes to nested font wire shape with correct aliases"""
         format_options = TextFormat(
-            bold=True,
-            italic=False,
-            fontSize=12,
-            fontName="Arial",
-            underline="Single",
+            font=WordFont(
+                bold=True,
+                italic=False,
+                size=12,
+                name="Arial",
+                underline="Single",
+            )
         )
 
         # Convert to dict (as it would be sent over Socket.IO)
         data = format_options.model_dump(by_alias=True, exclude_none=True)
 
-        assert data["bold"] is True
-        assert data["italic"] is False
-        assert data["fontSize"] == 12
-        assert data["fontName"] == "Arial"
-        assert data["underline"] == "Single"
+        assert data["font"]["bold"] is True
+        assert data["font"]["italic"] is False
+        assert data["font"]["size"] == 12
+        assert data["font"]["name"] == "Arial"
+        assert data["font"]["underline"] == "Single"
         # None values should be excluded with exclude_none=True
-        assert "color" not in data
+        assert "color" not in data["font"]
+        assert "highlightColor" not in data["font"]
         assert "styleName" not in data
 
     def test_format_from_dict(self) -> None:
-        """Test creating format from dict with aliases"""
+        """Test creating format from a nested-font dict with aliases"""
         format_options = TextFormat(
             **{
-                "bold": True,
-                "italic": True,
-                "fontSize": 14,
-                "color": "#FF0000",
-                "underline": "Double",
+                "font": {
+                    "bold": True,
+                    "italic": True,
+                    "size": 14,
+                    "color": "#FF0000",
+                    "underline": "Double",
+                },
                 "styleName": "Normal",
             }
         )
 
-        assert format_options.bold is True
-        assert format_options.italic is True
-        assert format_options.font_size == 14
-        assert format_options.color == "#FF0000"
-        assert format_options.underline == "Double"
+        assert format_options.font is not None
+        assert format_options.font.bold is True
+        assert format_options.font.italic is True
+        assert format_options.font.size == 14
+        assert format_options.font.color == "#FF0000"
+        assert format_options.font.underline == "Double"
         assert format_options.style_name == "Normal"
+
+    def test_font_and_style_name_coexist_serialization(self) -> None:
+        """New capability: font sub-object and styleName both serialize side by side (OASP 0.4.0)"""
+        format_options = TextFormat(
+            font=WordFont(bold=True, size=14),
+            style_name="Heading 1",
+        )
+
+        data = format_options.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["styleName"] == "Heading 1"
+        assert data["font"] == {"bold": True, "size": 14}
+
+
+class TestWordFont:
+    """Test WordFont DTO (OASP 0.4.0 font abstraction)"""
+
+    def test_all_fields_round_trip(self) -> None:
+        """snake_case input + camelCase wire aliases (size/name renamed from fontSize/fontName)"""
+        font = WordFont(
+            bold=True,
+            italic=False,
+            underline="Single",
+            size=14,
+            name="Calibri",
+            color="#1F4E79",
+            highlight_color="Yellow",
+        )
+
+        data = font.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["bold"] is True
+        assert data["italic"] is False
+        assert data["underline"] == "Single"
+        assert data["size"] == 14
+        assert data["name"] == "Calibri"
+        assert data["color"] == "#1F4E79"
+        assert data["highlightColor"] == "Yellow"
+
+    def test_highlight_color_round_trip(self) -> None:
+        """New capability: highlightColor accepts both preset name and hex, round-trips via alias"""
+        # Preset name
+        font_preset = WordFont(highlightColor="Yellow")
+        assert font_preset.highlight_color == "Yellow"
+        assert font_preset.model_dump(by_alias=True, exclude_none=True)["highlightColor"] == "Yellow"
+
+        # Hex value (snake_case input via populate_by_name)
+        font_hex = WordFont(highlight_color="#FFFF00")
+        assert font_hex.highlight_color == "#FFFF00"
+        assert font_hex.model_dump(by_alias=True, exclude_none=True)["highlightColor"] == "#FFFF00"
+
+    def test_new_underline_value_accepted(self) -> None:
+        """New capability: extended UnderlineStyle values (e.g. DashLine) are accepted"""
+        font = WordFont(underline="DashLine")
+        assert font.underline == "DashLine"
+
+        font_wave = WordFont(underline="WaveDouble")
+        assert font_wave.underline == "WaveDouble"
+
+    def test_removed_underline_value_rejected(self) -> None:
+        """Removed legacy underline values (Mixed/Hidden/DotLine) must be rejected"""
+        for removed in ("Mixed", "Hidden", "DotLine"):
+            with pytest.raises(ValidationError):
+                WordFont(underline=removed)  # type: ignore[arg-type]
+
+    def test_size_must_be_positive(self) -> None:
+        """size has gt=0 constraint (fontSize=0 no longer valid)"""
+        with pytest.raises(ValidationError):
+            WordFont(size=0)
+
+        with pytest.raises(ValidationError):
+            WordFont(size=-1)
 
 
 class TestWordGetStylesRequest:
@@ -1072,8 +1153,8 @@ class TestWordReplaceSelectionRequest:
         assert request.content.text is None
 
     def test_valid_request_with_text_and_format(self) -> None:
-        """Test creating valid request with text and format"""
-        text_format = TextFormat(bold=True, italic=True, fontSize=14)
+        """Test creating valid request with text and nested-font format"""
+        text_format = TextFormat(font=WordFont(bold=True, italic=True, size=14))
         content = ReplaceContent(text="Formatted text", format=text_format)
 
         request = WordReplaceSelectionRequest(
@@ -1084,21 +1165,23 @@ class TestWordReplaceSelectionRequest:
 
         assert request.content.text == "Formatted text"
         assert request.content.format is not None
-        assert request.content.format.bold is True
-        assert request.content.format.italic is True
-        assert request.content.format.font_size == 14
+        assert request.content.format.font is not None
+        assert request.content.format.font.bold is True
+        assert request.content.format.font.italic is True
+        assert request.content.format.font.size == 14
 
     def test_request_with_dict_content(self) -> None:
-        """Test creating request with content as dict"""
+        """Test creating request with content as dict (nested font)"""
         request = WordReplaceSelectionRequest(
             requestId="req_004",
             documentUri="file:///test.docx",
-            content={"text": "Test", "format": {"bold": True}},
+            content={"text": "Test", "format": {"font": {"bold": True}}},
         )
 
         assert request.content.text == "Test"
         assert request.content.format is not None
-        assert request.content.format.bold is True
+        assert request.content.format.font is not None
+        assert request.content.format.font.bold is True
 
     def test_missing_required_fields(self) -> None:
         """Test validation fails without required fields"""
@@ -1218,34 +1301,37 @@ class TestReplaceContent:
         assert content.format is None
 
     def test_content_with_text_and_format(self) -> None:
-        """Test creating content with text and format"""
+        """Test creating content with text and nested-font format"""
         format_obj = TextFormat(
-            bold=True,
-            italic=False,
-            fontSize=16,
-            fontName="Arial",
-            color="#FF0000",
+            font=WordFont(
+                bold=True,
+                italic=False,
+                size=16,
+                name="Arial",
+                color="#FF0000",
+            )
         )
         content = ReplaceContent(text="Bold red text", format=format_obj)
 
         assert content.text == "Bold red text"
         assert content.format is not None
-        assert content.format.bold is True
-        assert content.format.italic is False
-        assert content.format.font_size == 16
-        assert content.format.font_name == "Arial"
-        assert content.format.color == "#FF0000"
+        assert content.format.font is not None
+        assert content.format.font.bold is True
+        assert content.format.font.italic is False
+        assert content.format.font.size == 16
+        assert content.format.font.name == "Arial"
+        assert content.format.font.color == "#FF0000"
 
     def test_content_serialization(self) -> None:
-        """Test content can be serialized to dict with correct aliases"""
-        format_obj = TextFormat(bold=True, fontSize=14)
+        """Test content serializes to nested font wire shape with correct aliases"""
+        format_obj = TextFormat(font=WordFont(bold=True, size=14))
         content = ReplaceContent(text="Test", format=format_obj)
 
-        data = content.model_dump(by_alias=True)
+        data = content.model_dump(by_alias=True, exclude_none=True)
 
         assert data["text"] == "Test"
-        assert data["format"]["bold"] is True
-        assert data["format"]["fontSize"] == 14
+        assert data["format"]["font"]["bold"] is True
+        assert data["format"]["font"]["size"] == 14
 
 
 class TestWordGetSelectedContentResponse:
@@ -2956,22 +3042,22 @@ class TestCellFormat:
             CellFormat(verticalAlignment="Middle")
 
     def test_zero_font_size_rejected(self) -> None:
+        """font.size 仍受 gt=0 约束：CellFormat(font=WordFont(size=0)) 应被拒绝（OASP 0.4.0）"""
         with pytest.raises(ValidationError):
-            CellFormat(fontSize=0)
+            CellFormat(font=WordFont(size=0))
 
     def test_alias_round_trip(self) -> None:
-        """snake_case 输入 + camelCase 输出"""
+        """snake_case 输入 + camelCase 输出（字体收敛到 font 子对象）"""
         fmt = CellFormat(
             horizontal_alignment="Centered",
             background_color="#1F4E79",
-            font_color="#FFFFFF",
-            bold=True,
+            font=WordFont(color="#FFFFFF", bold=True),
         )
         payload = fmt.model_dump(by_alias=True, exclude_none=True)
         assert payload["horizontalAlignment"] == "Centered"
         assert payload["backgroundColor"] == "#1F4E79"
-        assert payload["fontColor"] == "#FFFFFF"
-        assert payload["bold"] is True
+        assert payload["font"]["color"] == "#FFFFFF"
+        assert payload["font"]["bold"] is True
 
 
 class TestTableSummary:
@@ -3058,8 +3144,7 @@ class TestWordUpdateTableCellRequest:
                         "horizontalAlignment": "Centered",
                         "verticalAlignment": "Center",
                         "backgroundColor": "#1F4E79",
-                        "fontColor": "#FFFFFF",
-                        "bold": True,
+                        "font": {"color": "#FFFFFF", "bold": True},
                     },
                 }
             ],
@@ -3071,6 +3156,8 @@ class TestWordUpdateTableCellRequest:
         assert cell["text"] == "甲方信息"
         assert cell["format"]["horizontalAlignment"] == "Centered"
         assert cell["format"]["backgroundColor"] == "#1F4E79"
+        assert cell["format"]["font"]["color"] == "#FFFFFF"
+        assert cell["format"]["font"]["bold"] is True
 
     def test_empty_cells_rejected(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit_tests/office4ai/environment/workspace/socketio/conftest.py
+++ b/tests/unit_tests/office4ai/environment/workspace/socketio/conftest.py
@@ -16,6 +16,10 @@ from office4ai.environment.workspace.socketio.services.connection_manager import
     ClientInfo,
     ConnectionManager,
 )
+from office4ai.environment.workspace.socketio.versioning import SERVER_VERSION
+
+# 与 Server 同版本的 oaspVersion（单一事实源，避免版本 bump 时握手 fixture 漂移）
+_COMPATIBLE_OASP_VERSION = str(SERVER_VERSION)
 
 
 @pytest.fixture
@@ -65,7 +69,7 @@ def valid_handshake_data() -> dict[str, Any]:
     return {
         "clientId": "test_client_123",
         "documentUri": "file:///tmp/test.docx",
-        "oaspVersion": "0.3.0",
+        "oaspVersion": _COMPATIBLE_OASP_VERSION,
     }
 
 
@@ -74,7 +78,7 @@ def invalid_handshake_data_missing_client_id() -> dict[str, Any]:
     """缺少 clientId 的无效握手数据（oaspVersion 合法，确保停在业务参数校验）"""
     return {
         "documentUri": "file:///tmp/test.docx",
-        "oaspVersion": "0.3.0",
+        "oaspVersion": _COMPATIBLE_OASP_VERSION,
     }
 
 
@@ -83,7 +87,7 @@ def invalid_handshake_data_missing_document_uri() -> dict[str, Any]:
     """缺少 documentUri 的无效握手数据（oaspVersion 合法，确保停在业务参数校验）"""
     return {
         "clientId": "test_client_123",
-        "oaspVersion": "0.3.0",
+        "oaspVersion": _COMPATIBLE_OASP_VERSION,
     }
 
 
@@ -93,7 +97,7 @@ def invalid_handshake_data_invalid_uri() -> dict[str, Any]:
     return {
         "clientId": "test_client_123",
         "documentUri": "invalid-uri-format",
-        "oaspVersion": "0.3.0",
+        "oaspVersion": _COMPATIBLE_OASP_VERSION,
     }
 
 

--- a/tests/unit_tests/office4ai/environment/workspace/socketio/test_request_wrapper.py
+++ b/tests/unit_tests/office4ai/environment/workspace/socketio/test_request_wrapper.py
@@ -73,20 +73,21 @@ class TestWrapRequest:
         assert wrapped1["requestId"] != wrapped2["requestId"]
 
     def test_wrap_word_insert_text(self) -> None:
-        """Test wrapping word:insert:text with all parameters"""
+        """Test wrapping word:insert:text with nested font format (OASP 0.4.0)"""
         business_params = {
             "document_uri": "file:///test.docx",
             "text": "Hello World",
             "location": "Cursor",
-            "format": {"bold": True, "fontSize": 14},
+            "format": {"font": {"bold": True, "size": 14}},
         }
 
         wrapped = wrap_request("word:insert:text", business_params)
 
         assert wrapped["text"] == "Hello World"
         assert wrapped["location"] == "Cursor"
-        assert wrapped["format"]["bold"] is True
-        assert wrapped["format"]["fontSize"] == 14
+        # font attributes consolidated under nested font sub-object (size renamed from fontSize)
+        assert wrapped["format"]["font"]["bold"] is True
+        assert wrapped["format"]["font"]["size"] == 14
 
     def test_wrap_excel_get_worksheet_info(self) -> None:
         """Test wrapping excel:get:worksheetInfo (snake_case worksheet_name → camelCase alias)"""
@@ -407,17 +408,18 @@ class TestWrapRequest:
         assert "worksheet_name" not in wrapped
 
     def test_wrap_ppt_insert_text(self) -> None:
-        """Test wrapping ppt:insert:text"""
+        """Test wrapping ppt:insert:text with nested font options (OASP 0.4.0)"""
         business_params = {
             "document_uri": "file:///test.pptx",
             "text": "Slide Title",
-            "options": {"fontSize": 32},
+            "options": {"font": {"size": 32}},
         }
 
         wrapped = wrap_request("ppt:insert:text", business_params)
 
         assert wrapped["text"] == "Slide Title"
-        assert wrapped["options"]["fontSize"] == 32
+        # font attributes consolidated under nested font sub-object (size renamed from fontSize)
+        assert wrapped["options"]["font"]["size"] == 32
 
 
 class TestIsWrappableEvent:

--- a/tests/unit_tests/office4ai/environment/workspace/socketio/test_versioning.py
+++ b/tests/unit_tests/office4ai/environment/workspace/socketio/test_versioning.py
@@ -78,8 +78,8 @@ class TestServerConstants:
     def test_server_version_matches_package(self) -> None:
         assert str(SERVER_VERSION) == __version__
 
-    def test_server_version_is_030(self) -> None:
-        assert (SERVER_VERSION.major, SERVER_VERSION.minor) == (0, 3)
+    def test_server_version_is_040(self) -> None:
+        assert (SERVER_VERSION.major, SERVER_VERSION.minor) == (0, 4)
 
     def test_min_max_window(self) -> None:
         assert SERVER_MIN_SUPPORTED == OaspVersion(SERVER_VERSION.major, SERVER_VERSION.minor, 0)

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ wheels = [
 
 [[package]]
 name = "office4ai"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 概述

office4ai Server 侧跟进 **OASP 协议 0.4.0** 的字体抽象收敛（协议已合并 oasp-protocol main）。DTO / MCP 工具入参 / 事件 payload / 声明版本与协议**逐字段对齐**。**clean-break**：扁平字体字段全部删除，改用嵌套 `font` 子对象。

一次覆盖今天协议 diff 的全部 3 块 + 版本 —— `Closes #74`（/word）· `Refs #45`（/ppt）· 对照 oasp-protocol#14 / #9。

## ⚠️ HELD — 暂不可合并

本变更把 Server 声明的 OASP 版本 bump 到 **0.4.0**。v0.x 握手要求 MINOR **严格相等**，任一端单独上 0.4.0 会与另一端 `2006 PROTOCOL_VERSION_MISMATCH` 断连。**合并前置**：
1. oasp-protocol 正式发布 `0.4.0`（当前在 `[Unreleased]`，由协议负责人手动发版）；
2. office-editor4ai `0.4.0` 就绪，**与本 PR 同版本成对上线**。

故本 PR 以 **draft** 挂起，待上述就绪后再转正式合并。

## 变更

### /word（Closes #74，oasp#14）
- 新增 `WordFont`（bold/italic/underline/size/name/color/highlightColor）；`TextFormat` = `{font?, styleName?}`、`CellFormat` 字体收敛为 `font`
- `UnderlineStyle` 21→**18 值**（删除仅回读 `Mixed` 与废弃 `Hidden`/`DotLine`，对齐 `Word.UnderlineType`）
- 事件 payload：`word:insert:text` / `append:text` / `replace:selection` / `replace:text`（`format.font`）、`word:update:tableCell`（`format.font`）

### /ppt（Refs #45，oasp#9）
- 新增 `PptFont`(12 属性) + `ShapeFontUnderlineStyle`(17)/`BulletType`/`BulletFormat`/`PptTextRun`/`PptParagraphStyle` + `ParagraphHorizontalAlignment`(7)/`TextVerticalAlignment`(6)
- `TextBoxUpdates` 增 `font`/`runs`/`paragraphs`；`TextInsertOptions` 增 `font`
- **`ppt:update:tableFormat`** 三级 formats（Cell/Row/Column）字体收敛 `PptFont` + 对齐改新枚举（**最易漏，已含**）
- `PptFont.size` `int`→`float`+`gt=0`（半磅字号，与 `WordFont.size` 对齐）

### 版本
- `__version__` / `pyproject.toml` `0.3.0`→`0.4.0`（`versioning.SERVER_VERSION` 从 `__version__` 派生）
- 握手 fixture（contract/unit/integration 三处 conftest + 两个 `INTEGRATION_AUTH`）改为从 `str(SERVER_VERSION)` 派生，杜绝硬编码漂移

### MCP 工具描述
- 6 处工具入参描述更新为嵌套 `font`，避免 LLM 产出被 `extra=ignore` **静默丢弃**的扁平字段

## 已知限制
- `WordFont.highlightColor` 的 `null=清除高亮`：`to_payload()` 全局 `exclude_none=True` 无法发出显式 `null` → 设色可用、清除不可表达。已在 DTO docstring 注明，留待后续（低频边缘能力）。

## 验证
- 全量测试 **1826 passed / 3 skipped**；`mypy office4ai` 无问题(154 files)；`ruff check`/`format` 全清
- 契约层经 MockAddIn 端到端校验请求侧真实 payload（tableFormat 三级、runs/paragraphs、insert:text font、`Center`/`Middle` 对齐枚举均有断言）
- 隔离 `code-reviewer` 子代理独立复审：**0 🔴**，3 🟡 已处理（size→float / 工具描述 / highlightColor 限制文档化）

## 关联
- 协议：oasp-protocol#14（/word，Merged）、oasp-protocol#9/#10（/ppt，Merged）
- Add-In 成对：office-editor4ai#74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
